### PR TITLE
Fix spawn-mode feature ingest settings

### DIFF
--- a/src/workbench/core/transforms/pandas_transforms/pandas_to_features.py
+++ b/src/workbench/core/transforms/pandas_transforms/pandas_to_features.py
@@ -365,17 +365,16 @@ class PandasToFeatures(Transform):
 
     @staticmethod
     def _ingest_settings():
-        """Return (max_workers, max_processes) based on platform.
+        """Return (max_workers, max_processes) based on multiprocessing mode.
 
-        macOS Tahoe 26+ / Python 3.13+ default to 'spawn' for multiprocessing. SageMaker V3's
-        _run_multi_process defines a local function (init_worker) that can't be pickled under
-        spawn, so any value > 1 crashes. On Linux (including AWS Batch) fork is the default
-        and multiprocessing works fine.
+        SageMaker V3's _run_multi_process defines a local function (init_worker) that can't be
+        pickled by spawn/forkserver workers, so any value > 1 crashes there. Fork workers inherit
+        the initializer in child memory, so multiprocessing can stay enabled on Linux/AWS Batch.
         See: https://github.com/aws/sagemaker-python-sdk/issues/5312
         """
-        import platform
+        import multiprocessing
 
-        if platform.system() == "Darwin":
+        if multiprocessing.get_start_method() != "fork":
             return 1, 1
         return 8, 4
 

--- a/tests/specific/feature_ingest_multiprocessing_test.py
+++ b/tests/specific/feature_ingest_multiprocessing_test.py
@@ -16,13 +16,25 @@ import multiprocessing
 from workbench.core.transforms.pandas_transforms import PandasToFeatures
 
 
-def test_ingest_settings():
-    """_ingest_settings() enables multiprocess ingest only under the 'fork' start method."""
+def test_ingest_settings_enables_multiprocess_for_fork(monkeypatch):
+    """_ingest_settings() enables multiprocess ingest under the 'fork' start method."""
+    monkeypatch.setattr(multiprocessing, "get_start_method", lambda: "fork")
+
     max_workers, max_processes = PandasToFeatures._ingest_settings()
-    if multiprocessing.get_start_method() == "fork":
-        assert max_workers > 1 or max_processes > 1, "fork should use multiprocess ingest"
-    else:
-        assert max_workers == 1 and max_processes == 1, "spawn/forkserver should use single-process ingest"
+
+    assert max_workers > 1 or max_processes > 1, "fork should use multiprocess ingest"
+
+
+def test_ingest_settings_uses_single_process_for_spawn_and_forkserver(monkeypatch):
+    """_ingest_settings() avoids unpicklable SageMaker workers under spawn/forkserver."""
+    for start_method in ("spawn", "forkserver"):
+        monkeypatch.setattr(multiprocessing, "get_start_method", lambda start_method=start_method: start_method)
+
+        max_workers, max_processes = PandasToFeatures._ingest_settings()
+
+        assert (max_workers, max_processes) == (1, 1), (
+            f"{start_method} should use single-process ingest because SageMaker's Pool initializer is unpicklable"
+        )
 
 
 def test_sagemaker_pool_initializer_unpicklable():


### PR DESCRIPTION
## Summary
- choose SageMaker feature ingest worker counts from the active multiprocessing start method instead of only checking for Darwin
- keep multiprocess ingest enabled for `fork`, and fall back to `(1, 1)` for `spawn`/`forkserver` where SageMaker's nested Pool initializer is unpicklable
- make the regression test explicit by monkeypatching the start method cases

Fixes #570.

## Testing
- `python -m py_compile src\workbench\core\transforms\pandas_transforms\pandas_to_features.py tests\specific\feature_ingest_multiprocessing_test.py`
- `PYTHONPATH=src WORKBENCH_SKIP_LOGGING=true python -m pytest tests/specific/feature_ingest_multiprocessing_test.py -q` (blocked locally: `ModuleNotFoundError: No module named 'pandas'` in this environment)