### PR TITLE
Remove unreachable plugin unit test callback setup

### DIFF
--- a/src/workbench/web_interface/components/plugin_unit_test.py
+++ b/src/workbench/web_interface/components/plugin_unit_test.py
@@ -138,18 +138,6 @@ class PluginUnitTest:
         else:
             raise ValueError(f"Invalid test type: {plugin_input_type}")
 
-        # Set up callbacks for displaying output signals
-        for component_id, property in self.plugin.signals:
-
-            @self.app.callback(
-                Output(f"test-output-{component_id}-{property}", "children"), Input(component_id, property)
-            )
-            def display_output_signal(signal_value):
-                return f"{signal_value}"
-
-        # Now register any internal callbacks
-        self.plugin.register_internal_callbacks()
-
     def run(self):
         """Run the Dash server for the plugin, handling common errors gracefully."""
         while self.is_port_in_use(self.port):


### PR DESCRIPTION
## Summary
- remove the duplicated signal callback/internal callback setup from _trigger_update() because every branch returns before that block
- keep the live callback registration in PluginUnitTest.__init__, where it is already reachable

Fixes #546.

## Validation
- python -m py_compile .\src\workbench\web_interface\components\plugin_unit_test.py`n- python -m flake8 .\src\workbench\web_interface\components\plugin_unit_test.py`n- git diff --check (clean aside from Git's Windows line-ending warning)