### PR TITLE
Update cleanlab Datalab requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ pip install workbench               # Default — API + REPL + orchestration.
 pip install 'workbench[ui]'         # + plotly, dash, dash-ag-grid,
                                     #   matplotlib. The Workbench Dashboard.
 
-pip install 'workbench[misc]'       # + networkx, cleanlab, datasets,
-                                    #   umap-learn. Specialized analysis libs
-                                    #   used by a handful of workflows.
+pip install 'workbench[misc]'       # + networkx, umap-learn. Specialized
+                                    #   analysis libs used by a handful of
+                                    #   workflows.
 
 pip install 'workbench[dev]'        # + pytest, pytest-xdist, coverage,
                                     #   flake8, black. Local development.
@@ -133,6 +133,9 @@ pip install 'workbench[all]'        # ui + misc + dev — full install for
 ```
 
 *Note: shells may interpret square brackets as globs, so the quotes are needed.*
+
+Cleanlab/Datalab workflows are optional and are not included in the Workbench
+extras. Install `cleanlab[datalab]>=2.8.0` before calling `cleanlab_model()`.
 
 #### Endpoint container surface
 

--- a/src/workbench/algorithms/models/cleanlab_model.py
+++ b/src/workbench/algorithms/models/cleanlab_model.py
@@ -5,9 +5,9 @@ of its extras. Users who want to use :class:`CleanlabModels` (via
 :meth:`workbench.api.Model.cleanlab_model` or
 :meth:`workbench.api.FeatureSet.cleanlab_model`) must install it separately::
 
-    pip install 'cleanlab[datalab]' 'datasets<4.0.0'
+    pip install 'cleanlab[datalab]>=2.8.0'
 
-The ``datasets<4.0.0`` pin works around a Datalab bug:
+Cleanlab 2.8.0+ includes the Datalab fix for datasets 4.x:
 https://github.com/cleanlab/cleanlab/issues/1253
 
 This module imports cleanly even when cleanlab is not installed; the
@@ -24,17 +24,36 @@ from sklearn.preprocessing import LabelEncoder
 
 from workbench.core.artifacts.model_core import ModelType
 
+
+def _major_minor(version: str) -> tuple[int, int]:
+    parts = []
+    for raw_part in version.split(".")[:2]:
+        digits = ""
+        for char in raw_part:
+            if not char.isdigit():
+                break
+            digits += char
+        parts.append(int(digits or 0))
+    while len(parts) < 2:
+        parts.append(0)
+    return parts[0], parts[1]
+
+
+def _is_old_cleanlab_with_new_datasets(cleanlab_version: str, datasets_version: str) -> bool:
+    return _major_minor(cleanlab_version) < (2, 8) and _major_minor(datasets_version)[0] >= 4
+
+
 # Optional dependency check — see module docstring.
 _CLEANLAB_IMPORT_ERROR: Optional[str] = None
 try:
     import datasets
+    import cleanlab
 
-    _datasets_major = int(datasets.__version__.split(".")[0])
-    if _datasets_major >= 4:
+    if _is_old_cleanlab_with_new_datasets(cleanlab.__version__, datasets.__version__):
         raise ImportError(
-            "cleanlab's Datalab requires datasets<4.0.0 due to a known bug "
+            f"cleanlab {cleanlab.__version__} is incompatible with datasets {datasets.__version__} "
             "(https://github.com/cleanlab/cleanlab/issues/1253). "
-            "Fix: pip install 'datasets<4.0.0'"
+            "Fix: pip install 'cleanlab[datalab]>=2.8.0'"
         )
     from cleanlab.regression.learn import CleanLearning as CleanLearningRegressor
     from cleanlab.classification import CleanLearning as CleanLearningClassifier
@@ -49,7 +68,7 @@ except ImportError as _e:
     _CLEANLAB_IMPORT_ERROR = (
         f"{_e}. "
         "cleanlab is an optional workbench dependency — install with: "
-        "pip install 'cleanlab[datalab]' 'datasets<4.0.0'"
+        "pip install 'cleanlab[datalab]>=2.8.0'"
     )
 
 # Regressor types for convenience

--- a/tests/specific/cleanlab_version_guard_test.py
+++ b/tests/specific/cleanlab_version_guard_test.py
@@ -1,0 +1,17 @@
+from workbench.algorithms.models.cleanlab_model import _is_old_cleanlab_with_new_datasets
+
+
+def test_cleanlab_2_8_allows_datasets_4():
+    assert not _is_old_cleanlab_with_new_datasets("2.8.0", "4.0.0")
+
+
+def test_cleanlab_2_9_allows_current_datasets():
+    assert not _is_old_cleanlab_with_new_datasets("2.9.0", "4.8.5")
+
+
+def test_cleanlab_2_7_blocks_datasets_4():
+    assert _is_old_cleanlab_with_new_datasets("2.7.1", "4.0.0")
+
+
+def test_cleanlab_2_7_allows_datasets_3():
+    assert not _is_old_cleanlab_with_new_datasets("2.7.1", "3.6.0")


### PR DESCRIPTION
Fixes #551.

Summary:
- update the optional cleanlab install guidance to `cleanlab[datalab]>=2.8.0`
- allow `datasets>=4` when cleanlab is new enough, while preserving the guard for `cleanlab<2.8` with `datasets>=4`
- correct the README `misc` extra description now that cleanlab/datasets are not included there
- add focused version-guard coverage

Tests:
- `py -m py_compile src\workbench\algorithms\models\cleanlab_model.py tests\specific\cleanlab_version_guard_test.py`
- `git diff --check`
- `PYTHONPATH=src py -m pytest tests\specific\cleanlab_version_guard_test.py -q` is blocked in this local environment by missing project dependency `botocore`