### PR TITLE
Cache model hyperparameter artifact loads

### DIFF
--- a/src/workbench/utils/model_utils.py
+++ b/src/workbench/utils/model_utils.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
+from functools import lru_cache
 import pandas as pd
 import numpy as np
 from scipy.stats import spearmanr
@@ -435,7 +437,12 @@ def load_category_mappings_from_s3(model_artifact_uri: str) -> Optional[dict]:
     return category_mappings
 
 
-def load_hyperparameters_from_s3(model_artifact_uri: str) -> Optional[dict]:
+@lru_cache(maxsize=128)
+def _load_hyperparameters_from_s3_cached(model_artifact_uri: str) -> Optional[dict]:
+    return _load_hyperparameters_from_s3_uncached(model_artifact_uri)
+
+
+def _load_hyperparameters_from_s3_uncached(model_artifact_uri: str) -> Optional[dict]:
     """
     Download and extract hyperparameters from a model artifact in S3.
 
@@ -467,6 +474,16 @@ def load_hyperparameters_from_s3(model_artifact_uri: str) -> Optional[dict]:
                 log.warning(f"Failed to load hyperparameters from {hyperparameters_path}: {e}")
 
     return hyperparameters
+
+
+def load_hyperparameters_from_s3(model_artifact_uri: str) -> Optional[dict]:
+    """
+    Download and extract hyperparameters from a model artifact in S3.
+
+    Results are cached by model artifact URI so repeated model summary/details
+    calls do not download and extract the same immutable artifact more than once.
+    """
+    return deepcopy(_load_hyperparameters_from_s3_cached(model_artifact_uri))
 
 
 def get_model_hyperparameters(workbench_model: Any) -> Optional[dict]:

--- a/tests/specific/hyperparameters_cache_test.py
+++ b/tests/specific/hyperparameters_cache_test.py
@@ -1,0 +1,25 @@
+from workbench.utils import model_utils
+
+
+def test_hyperparameters_are_cached_by_model_artifact_uri(monkeypatch):
+    calls = []
+
+    def fake_load(model_artifact_uri):
+        calls.append(model_artifact_uri)
+        return {"source": model_artifact_uri, "nested": {"calls": len(calls)}}
+
+    model_utils._load_hyperparameters_from_s3_cached.cache_clear()
+    monkeypatch.setattr(model_utils, "_load_hyperparameters_from_s3_uncached", fake_load)
+
+    try:
+        first = model_utils.load_hyperparameters_from_s3("s3://bucket/model.tar.gz")
+        first["nested"]["calls"] = 999
+
+        second = model_utils.load_hyperparameters_from_s3("s3://bucket/model.tar.gz")
+        third = model_utils.load_hyperparameters_from_s3("s3://bucket/other-model.tar.gz")
+    finally:
+        model_utils._load_hyperparameters_from_s3_cached.cache_clear()
+
+    assert calls == ["s3://bucket/model.tar.gz", "s3://bucket/other-model.tar.gz"]
+    assert second == {"source": "s3://bucket/model.tar.gz", "nested": {"calls": 1}}
+    assert third == {"source": "s3://bucket/other-model.tar.gz", "nested": {"calls": 2}}


### PR DESCRIPTION
## Summary\n- Cache hyperparameter loads by model artifact URI so repeated summary/details calls do not download and extract the same S3 artifact repeatedly.\n- Return a deep copy from the cache so callers cannot mutate the cached value.\n- Add focused coverage for cache reuse across repeated URIs and separate cache entries for different artifacts.\n\nFixes #557.\n\n## Verification\n- py -m py_compile src\\workbench\\utils\\model_utils.py tests\\specific\\hyperparameters_cache_test.py\n- git diff --check\n- PYTHONPATH=src py -m pytest tests\\specific\\hyperparameters_cache_test.py -q is blocked in this local environment by missing otocore during workbench package initialization.