### PR TITLE
Add CMake dependency for XGBoost builds

### DIFF
--- a/applications/aws_dashboard/requirements.lock
+++ b/applications/aws_dashboard/requirements.lock
@@ -89,6 +89,8 @@ cloudpickle==3.1.2
     # via
     #   mlflow-skinny
     #   sagemaker-core
+cmake==4.3.2
+    # via workbench (pyproject.toml)
 contourpy==1.3.3
     # via matplotlib
 cryptography==46.0.7

--- a/applications/compound_explorer/requirements.lock
+++ b/applications/compound_explorer/requirements.lock
@@ -90,6 +90,8 @@ cloudpickle==3.1.2
     #   mlflow-skinny
     #   sagemaker-core
     #   shap
+cmake==4.3.2
+    # via workbench (pyproject.toml)
 contourpy==1.3.3
     # via matplotlib
 cryptography==46.0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
     # Data / ML
     "pandas >= 2.2.1, < 3.0",
     "scikit-learn >= 1.5.2",
+    # XGBoost source builds invoke CMake when no wheel matches the platform.
+    "cmake >= 3.18",
     "xgboost >= 3.0.3",
     "joblib >= 1.3.2",
     # Cheminformatics

--- a/sagemaker_images/ml_pipelines/requirements.lock
+++ b/sagemaker_images/ml_pipelines/requirements.lock
@@ -87,6 +87,8 @@ cloudpickle==3.1.2
     # via
     #   mlflow-skinny
     #   sagemaker-core
+cmake==4.3.2
+    # via workbench (pyproject.toml)
 contourpy==1.3.3
     # via matplotlib
 cryptography==46.0.7

--- a/tests/specific/xgboost_dependency_test.py
+++ b/tests/specific/xgboost_dependency_test.py
@@ -1,0 +1,14 @@
+import tomllib
+from pathlib import Path
+
+
+def test_xgboost_source_build_dependency_is_declared_before_xgboost():
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    metadata = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    dependencies = metadata["project"]["dependencies"]
+
+    cmake_index = next(i for i, spec in enumerate(dependencies) if spec.startswith("cmake "))
+    xgboost_index = next(i for i, spec in enumerate(dependencies) if spec.startswith("xgboost "))
+
+    assert "cmake >= 3.18" in dependencies
+    assert cmake_index < xgboost_index


### PR DESCRIPTION
## Summary
- add `cmake >= 3.18` before `xgboost` so source builds have the CMake requirement available when wheels are not usable
- refresh the pyproject-derived image/application lockfiles with `cmake==4.3.2`
- add a focused metadata guard that keeps the CMake dependency declared ahead of xgboost

Closes #532

## Tests
- `py -m py_compile tests\specific\xgboost_dependency_test.py`
- `py -m pytest tests\specific\xgboost_dependency_test.py -q`
- `git diff --check`
- `py -m uv pip compile ...` for the three pyproject-derived lockfiles with the CPU PyTorch index