### PR TITLE
Guard artifact cache writes

### DIFF
--- a/src/workbench/cached/cached_artifact_mixin.py
+++ b/src/workbench/cached/cached_artifact_mixin.py
@@ -2,6 +2,7 @@
 
 import logging
 from functools import wraps
+
 from workbench.utils.workbench_cache import WorkbenchCache
 
 
@@ -15,6 +16,21 @@ class CachedArtifactMixin:
     # Class-level cache for artifact method results
     log = logging.getLogger("workbench")
     artifact_cache = WorkbenchCache(prefix="artifact_cache")
+    max_cached_result_bytes = 1024 * 1024
+
+    @classmethod
+    def _result_size_bytes(cls, result):
+        """Best-effort size estimate for deciding whether a result belongs in Redis."""
+        try:
+            if hasattr(result, "memory_usage"):
+                memory_usage = result.memory_usage(deep=True)
+                if hasattr(memory_usage, "sum"):
+                    return int(memory_usage.sum())
+                return int(memory_usage)
+            return len(str(result))
+        except Exception as e:
+            cls.log.warning(f"Cache: Could not estimate result size: {e}")
+            return None
 
     @classmethod
     def cache_result(cls, method):
@@ -44,7 +60,18 @@ class CachedArtifactMixin:
 
             # Stale or first access: fetch fresh data
             result = method(self, *args, **kwargs)
-            cls.artifact_cache.set(cache_key, {"_result": result, "_modified": current_modified})
+            result_size = cls._result_size_bytes(result)
+            if result_size is not None and result_size > cls.max_cached_result_bytes:
+                self.log.warning(
+                    "Cache: Skipping oversized cached result "
+                    f"({cache_key}: {result_size} bytes > {cls.max_cached_result_bytes})"
+                )
+                return result
+
+            try:
+                cls.artifact_cache.set(cache_key, {"_result": result, "_modified": current_modified})
+            except Exception as e:
+                self.log.warning(f"Cache: Skipping cached result for {cache_key} after cache write failed: {e}")
             return result
 
         return wrapper
@@ -71,6 +98,7 @@ class CachedArtifactMixin:
 # Example usage of CachedModel
 if __name__ == "__main__":
     from pprint import pprint
+
     from workbench.cached.cached_model import CachedModel
 
     my_model = CachedModel("abalone-regression")

--- a/tests/specific/cached_artifact_cache_guard_test.py
+++ b/tests/specific/cached_artifact_cache_guard_test.py
@@ -1,0 +1,108 @@
+# isort: skip_file
+import logging
+import sys
+import types
+
+
+class FakeWorkbenchCache:
+    def __init__(self, *args, **kwargs):
+        self.values = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value):
+        self.values[key] = value
+
+    @staticmethod
+    def flatten_key(name, *args, **kwargs):
+        key_name = name.__name__ if callable(name) else name
+        return f"{key_name}_{args}_{kwargs}"
+
+
+fake_workbench_cache_module = types.ModuleType("workbench.utils.workbench_cache")
+fake_workbench_cache_module.WorkbenchCache = FakeWorkbenchCache
+sys.modules.setdefault("workbench.utils.workbench_cache", fake_workbench_cache_module)
+
+from workbench.cached.cached_artifact_mixin import CachedArtifactMixin  # noqa: E402
+
+
+class FakeMeta:
+    def get_modified_timestamp(self, artifact):
+        return "2026-06-01T00:00:00Z"
+
+
+class FakeCache:
+    def __init__(self, fail_on_set=False):
+        self.fail_on_set = fail_on_set
+        self.values = {}
+        self.set_calls = 0
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value):
+        self.set_calls += 1
+        if self.fail_on_set:
+            raise RuntimeError("command not allowed when used memory > 'maxmemory'")
+        self.values[key] = value
+
+
+def install_fake_meta(monkeypatch):
+    fake_meta_module = types.ModuleType("workbench.cached.cached_meta")
+    fake_meta_module.CachedMeta = FakeMeta
+    monkeypatch.setitem(sys.modules, "workbench.cached.cached_meta", fake_meta_module)
+
+
+class DummyArtifact:
+    name = "dummy"
+    log = logging.getLogger("workbench")
+
+    def __init__(self, value):
+        self.value = value
+        self.calls = 0
+
+    @CachedArtifactMixin.cache_result
+    def expensive_value(self):
+        self.calls += 1
+        return self.value
+
+
+def test_oversized_result_is_returned_without_cache_write(monkeypatch):
+    fake_cache = FakeCache()
+    install_fake_meta(monkeypatch)
+    monkeypatch.setattr(CachedArtifactMixin, "artifact_cache", fake_cache)
+    monkeypatch.setattr(CachedArtifactMixin, "max_cached_result_bytes", 10)
+
+    artifact = DummyArtifact("x" * 20)
+
+    assert artifact.expensive_value() == "x" * 20
+    assert artifact.calls == 1
+    assert fake_cache.set_calls == 0
+
+
+def test_cache_write_failure_returns_fresh_result(monkeypatch):
+    fake_cache = FakeCache(fail_on_set=True)
+    install_fake_meta(monkeypatch)
+    monkeypatch.setattr(CachedArtifactMixin, "artifact_cache", fake_cache)
+    monkeypatch.setattr(CachedArtifactMixin, "max_cached_result_bytes", 1024)
+
+    artifact = DummyArtifact("fresh-result")
+
+    assert artifact.expensive_value() == "fresh-result"
+    assert artifact.calls == 1
+    assert fake_cache.set_calls == 1
+
+
+def test_cache_still_stores_small_results(monkeypatch):
+    fake_cache = FakeCache()
+    install_fake_meta(monkeypatch)
+    monkeypatch.setattr(CachedArtifactMixin, "artifact_cache", fake_cache)
+    monkeypatch.setattr(CachedArtifactMixin, "max_cached_result_bytes", 1024)
+
+    artifact = DummyArtifact("small-result")
+
+    assert artifact.expensive_value() == "small-result"
+    assert artifact.expensive_value() == "small-result"
+    assert artifact.calls == 1
+    assert fake_cache.set_calls == 1


### PR DESCRIPTION
## Summary
- skip artifact-cache writes for oversized results before they are pushed into Redis
- return fresh results when a cache write fails, instead of letting Redis maxmemory errors break the caller
- add focused coverage for oversized-result skips, cache-write failures, and normal small-result caching

Fixes #553.

## Verification
- `py -m py_compile src\workbench\cached\cached_artifact_mixin.py tests\specific\cached_artifact_cache_guard_test.py`
- `WORKBENCH_SKIP_LOGGING=true PYTHONPATH=src py -m pytest tests\specific\cached_artifact_cache_guard_test.py -q`
- `py -m flake8 src\workbench\cached\cached_artifact_mixin.py tests\specific\cached_artifact_cache_guard_test.py`
- `py -m black --check src\workbench\cached\cached_artifact_mixin.py tests\specific\cached_artifact_cache_guard_test.py`
- `py -m isort --check src\workbench\cached\cached_artifact_mixin.py tests\specific\cached_artifact_cache_guard_test.py`
- `git diff --check`