### PR TITLE
Reduce model metadata detail calls

### DIFF
--- a/src/workbench/cached/cached_meta.py
+++ b/src/workbench/cached/cached_meta.py
@@ -2,10 +2,11 @@
 
 import logging
 import time
-import pandas as pd
 from datetime import datetime, timezone
 from functools import wraps
 from typing import TYPE_CHECKING, Optional
+
+import pandas as pd
 
 # Workbench Imports
 from workbench.core.cloud_platform.cloud_meta import CloudMeta
@@ -335,6 +336,8 @@ class CachedMeta(CloudMeta):
 
         # Step 3: If no cached details, fetch everything
         if cached_df is None or not isinstance(cached_df, pd.DataFrame) or cached_df.empty:
+            if list_method == "models":
+                return super().models(details=True)
             rows = [detail_method(name) for name in lightweight_df[name_col]]
             df = pd.DataFrame(rows).convert_dtypes()
             if not df.empty:

--- a/src/workbench/core/cloud_platform/aws/aws_meta.py
+++ b/src/workbench/core/cloud_platform/aws/aws_meta.py
@@ -4,16 +4,17 @@ AWS Artifacts, such as Data Sources, Feature Sets, Models, and Endpoints.
 """
 
 import logging
+from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Union
-import pandas as pd
+
 import awswrangler as wr
-from collections import defaultdict
+import pandas as pd
 
 # Workbench Imports
 from workbench.core.cloud_platform.aws.aws_account_clamp import AWSAccountClamp
+from workbench.utils.aws_utils import aws_tags_to_dict, aws_throttle, not_found_returns_none
 from workbench.utils.config_manager import ConfigManager
-from workbench.utils.aws_utils import not_found_returns_none, aws_throttle, aws_tags_to_dict
 
 
 def to_utc(dt):
@@ -238,7 +239,7 @@ class AWSMeta:
         for page in paginator.paginate():
             for group in page["ModelPackageGroupSummaryList"]:
                 if details:
-                    model_summary.append(self._model_detail_row(group["ModelPackageGroupName"]))
+                    model_summary.append(self._model_detail_row(group["ModelPackageGroupName"], group_info=group))
                 else:
                     name = group["ModelPackageGroupName"]
                     created = to_utc(group["CreationTime"])
@@ -266,30 +267,31 @@ class AWSMeta:
             df.sort_values(by="Created", ascending=False, inplace=True)
         return df
 
-    def _model_detail_row(self, name: str) -> dict:
+    def _model_detail_row(self, name: str, group_info: Union[dict, None] = None) -> dict:
         """Fetch a detail summary row for a single Model.
 
         Args:
             name (str): The model package group name.
+            group_info (dict, optional): Existing ModelPackageGroup summary/detail.
 
         Returns:
             dict: A summary row dict with all detail fields populated.
         """
-        group_info = self.sm_client.describe_model_package_group(ModelPackageGroupName=name)
+        if group_info is None:
+            group_info = self.sm_client.describe_model_package_group(ModelPackageGroupName=name)
+
         created = to_utc(group_info["CreationTime"])
         description = group_info.get("ModelPackageGroupDescription", "-")
 
-        model_details = {}
         aws_tags = {}
         status = "Unknown"
         health_tags = ""
 
         latest_model = self.get_latest_model_package_info(name)
         if latest_model:
-            model_details = self.sm_client.describe_model_package(ModelPackageName=latest_model["ModelPackageArn"])
-            aws_tags = self.get_aws_tags(group_info["ModelPackageGroupArn"])
+            aws_tags = self.get_aws_tags(group_info.get("ModelPackageGroupArn")) or {}
             health_tags = aws_tags.get("workbench_health_tags", "")
-            status = model_details.get("ModelPackageStatus", "Unknown")
+            status = latest_model.get("ModelPackageStatus", "Unknown")
         else:
             health_tags = "model_not_found"
             status = "No Models"
@@ -302,7 +304,7 @@ class AWSMeta:
             "Framework": aws_tags.get("workbench_model_framework", "-"),
             "Created": created,
             "Modified": created,
-            "Ver": model_details.get("ModelPackageVersion", "-"),
+            "Ver": latest_model.get("ModelPackageVersion", "-") if latest_model else "-",
             "Input": aws_tags.get("workbench_input", "-"),
             "Status": status,
             "Description": description,

--- a/tests/specific/aws_meta_model_details_test.py
+++ b/tests/specific/aws_meta_model_details_test.py
@@ -1,0 +1,170 @@
+# isort: skip_file
+"""Unit coverage for lightweight SageMaker model metadata summaries."""
+
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime, timezone
+
+os.environ["WORKBENCH_SKIP_LOGGING"] = "true"
+
+
+def _install_optional_dependency_stubs():
+    """Keep this focused unit test runnable without the full AWS dependency stack."""
+
+    if importlib.util.find_spec("pandas") is None:
+        pandas = types.ModuleType("pandas")
+
+        class DataFrame:
+            def __init__(self, rows=None):
+                self.rows = list(rows or [])
+
+            @property
+            def empty(self):
+                return not self.rows
+
+            @property
+            def loc(self):
+                frame = self
+
+                class Loc:
+                    def __getitem__(self, key):
+                        row_index, column = key
+                        return frame.rows[row_index][column]
+
+                return Loc()
+
+            def convert_dtypes(self):
+                return self
+
+            def sort_values(self, by, ascending=True, inplace=False):
+                rows = sorted(self.rows, key=lambda row: row[by], reverse=not ascending)
+                if inplace:
+                    self.rows = rows
+                    return None
+                return DataFrame(rows)
+
+        pandas.DataFrame = DataFrame
+        sys.modules["pandas"] = pandas
+
+    if importlib.util.find_spec("awswrangler") is None:
+        sys.modules["awswrangler"] = types.ModuleType("awswrangler")
+
+    if importlib.util.find_spec("boto3") is not None and importlib.util.find_spec("botocore") is not None:
+        return
+
+    account_clamp = types.ModuleType("workbench.core.cloud_platform.aws.aws_account_clamp")
+
+    class AWSAccountClamp:
+        pass
+
+    account_clamp.AWSAccountClamp = AWSAccountClamp
+    sys.modules["workbench.core.cloud_platform.aws.aws_account_clamp"] = account_clamp
+
+    config_manager = types.ModuleType("workbench.utils.config_manager")
+
+    class ConfigManager:
+        pass
+
+    config_manager.ConfigManager = ConfigManager
+    sys.modules["workbench.utils.config_manager"] = config_manager
+
+    aws_utils = types.ModuleType("workbench.utils.aws_utils")
+
+    def identity_decorator(func=None, **_kwargs):
+        if func is None:
+            return lambda inner: inner
+        return func
+
+    aws_utils.not_found_returns_none = identity_decorator
+    aws_utils.aws_throttle = identity_decorator
+    aws_utils.aws_tags_to_dict = lambda tags: {tag["Key"]: tag["Value"] for tag in tags}
+    sys.modules["workbench.utils.aws_utils"] = aws_utils
+
+
+_install_optional_dependency_stubs()
+
+from workbench.core.cloud_platform.aws.aws_meta import AWSMeta  # noqa: E402
+
+
+class FakePaginator:
+    def __init__(self, groups):
+        self.groups = groups
+
+    def paginate(self):
+        return [{"ModelPackageGroupSummaryList": self.groups}]
+
+
+class FakeSageMakerClient:
+    def __init__(self):
+        self.calls = []
+        self.group = {
+            "ModelPackageGroupName": "demo-model",
+            "ModelPackageGroupArn": "arn:aws:sagemaker:us-east-1:123:model-package-group/demo-model",
+            "CreationTime": datetime(2026, 1, 2, tzinfo=timezone.utc),
+            "ModelPackageGroupDescription": "demo description",
+        }
+        self.latest_package = {
+            "ModelPackageArn": "arn:aws:sagemaker:us-east-1:123:model-package/demo-model/7",
+            "ModelPackageStatus": "Completed",
+            "ModelPackageVersion": 7,
+        }
+
+    def get_paginator(self, operation):
+        self.calls.append(("get_paginator", operation))
+        return FakePaginator([self.group])
+
+    def describe_model_package_group(self, **kwargs):
+        self.calls.append(("describe_model_package_group", kwargs))
+        return self.group
+
+    def list_model_packages(self, **kwargs):
+        self.calls.append(("list_model_packages", kwargs))
+        return {"ModelPackageSummaryList": [self.latest_package]}
+
+    def describe_model_package(self, **kwargs):
+        self.calls.append(("describe_model_package", kwargs))
+        raise AssertionError("model summaries should not call describe_model_package")
+
+
+def make_meta(client):
+    meta = AWSMeta.__new__(AWSMeta)
+    meta.sm_client = client
+    meta.boto3_session = types.SimpleNamespace(region_name="us-east-1")
+    meta.account_clamp = types.SimpleNamespace(region="us-east-1")
+    meta.get_aws_tags = lambda arn: {
+        "workbench_owner": "owner",
+        "workbench_model_type": "classifier",
+        "workbench_model_framework": "xgboost",
+        "workbench_input": "features",
+        "workbench_tags": "tag-a",
+        "workbench_health_tags": "healthy",
+    }
+    return meta
+
+
+def test_models_details_reuses_group_and_package_summaries():
+    client = FakeSageMakerClient()
+    meta = make_meta(client)
+
+    df = meta.models(details=True)
+
+    assert df.loc[0, "Model Group"] == "demo-model"
+    assert df.loc[0, "Ver"] == 7
+    assert df.loc[0, "Status"] == "Completed"
+    assert df.loc[0, "Owner"] == "owner"
+    assert "describe_model_package_group" not in [call[0] for call in client.calls]
+    assert "describe_model_package" not in [call[0] for call in client.calls]
+
+
+def test_model_detail_row_uses_latest_package_summary_for_version_and_status():
+    client = FakeSageMakerClient()
+    meta = make_meta(client)
+
+    row = meta._model_detail_row("demo-model")
+
+    assert row["Ver"] == 7
+    assert row["Status"] == "Completed"
+    assert row["Description"] == "demo description"
+    assert "describe_model_package" not in [call[0] for call in client.calls]


### PR DESCRIPTION
## Summary
- build `models(details=True)` rows from the model-package-group summaries already returned by SageMaker
- use the latest `list_model_packages` summary for version/status instead of an extra `describe_model_package` call
- let the initial `CachedMeta.models(details=True)` fill use the optimized model listing path
- add focused tests that fail if the extra describe calls come back

Fixes #526

## Tests
- `WORKBENCH_SKIP_LOGGING=true PYTHONPATH=src py -m pytest tests\specific\aws_meta_model_details_test.py -q`
- `py -m flake8 src\workbench\core\cloud_platform\aws\aws_meta.py src\workbench\cached\cached_meta.py tests\specific\aws_meta_model_details_test.py`
- `py -m black --check src\workbench\core\cloud_platform\aws\aws_meta.py src\workbench\cached\cached_meta.py tests\specific\aws_meta_model_details_test.py`
- `py -m py_compile src\workbench\core\cloud_platform\aws\aws_meta.py src\workbench\cached\cached_meta.py tests\specific\aws_meta_model_details_test.py`
- `git diff --check`