### PR TITLE
Set Athena query output path

### DIFF
--- a/src/workbench/api/inference_store.py
+++ b/src/workbench/api/inference_store.py
@@ -2,12 +2,14 @@
 
 import logging
 import time
+
 import pandas as pd
 import awswrangler as wr
 
 # Workbench Imports
 from workbench.core.cloud_platform.aws.boto_session import get_boto3_session
 from workbench.utils.athena_utils import (
+    athena_output_s3_path,
     dataframe_to_table,
     table_s3_path,
     delete_table,
@@ -120,6 +122,7 @@ class InferenceStore:
                 database=self.catalog_db,
                 ctas_approach=False,
                 boto3_session=self.boto3_session,
+                s3_output=athena_output_s3_path(),
             )
             execution_time = time.time() - start_time
             self.log.info(f"Query completed in {execution_time:.2f} seconds")

--- a/src/workbench/core/artifacts/athena_source.py
+++ b/src/workbench/core/artifacts/athena_source.py
@@ -15,7 +15,7 @@ from workbench.utils.datetime_utils import convert_all_to_iso8601
 from workbench.algorithms import sql
 from workbench.utils.json_utils import CustomEncoder
 from workbench.utils.aws_utils import decode_value
-from workbench.utils.athena_utils import compute_athena_table_hash
+from workbench.utils.athena_utils import athena_output_s3_path, compute_athena_table_hash
 from workbench.utils.s3_utils import compute_parquet_hash
 from workbench.core.cloud_platform.aws.cache_dataframe import cache_dataframe
 
@@ -181,7 +181,7 @@ class AthenaSource(DataSourceAbstract):
 
     def table_hash(self) -> str:
         """Get the table hash for this AthenaSource"""
-        s3_scratch = f"s3://{self.workbench_bucket}/temp/athena_output"
+        s3_scratch = athena_output_s3_path(self.workbench_bucket)
         return compute_athena_table_hash(self.database, self.table, self.boto3_session, s3_scratch)
 
     def num_rows(self) -> int:
@@ -234,6 +234,7 @@ class AthenaSource(DataSourceAbstract):
                 database=database,
                 ctas_approach=False,
                 boto3_session=cls.boto3_session,
+                s3_output=athena_output_s3_path(cls.workbench_bucket),
             )
             scanned_bytes = df.query_metadata["Statistics"]["DataScannedInBytes"]
             if scanned_bytes > 0:
@@ -260,6 +261,7 @@ class AthenaSource(DataSourceAbstract):
                     sql=query,
                     database=self.database,
                     boto3_session=self.boto3_session,
+                    s3_output=athena_output_s3_path(self.workbench_bucket),
                 )
                 self.log.debug(f"QueryExecutionId: {query_execution_id}")
 
@@ -299,6 +301,7 @@ class AthenaSource(DataSourceAbstract):
             database=self.database,
             ctas_approach=False,
             boto3_session=self.boto3_session,
+            s3_output=athena_output_s3_path(self.workbench_bucket),
         )
         scanned_bytes = df.query_metadata["Statistics"]["DataScannedInBytes"]
         self.log.info(f"Athena TEST Query successful (scanned bytes: {scanned_bytes})")
@@ -483,7 +486,10 @@ class AthenaSource(DataSourceAbstract):
         # Compute our AWS URL
         query = f'select * from "{self.database}.{self.table}" limit 10'
         query_exec_id = wr.athena.start_query_execution(
-            sql=query, database=self.database, boto3_session=self.boto3_session
+            sql=query,
+            database=self.database,
+            boto3_session=self.boto3_session,
+            s3_output=athena_output_s3_path(self.workbench_bucket),
         )
         base_url = "https://console.aws.amazon.com/athena/home"
         details["aws_url"] = f"{base_url}?region={self.aws_region}#query/history/{query_exec_id}"

--- a/src/workbench/core/transforms/data_to_features/heavy/chunk/data_to_features_chunk.py
+++ b/src/workbench/core/transforms/data_to_features/heavy/chunk/data_to_features_chunk.py
@@ -8,6 +8,7 @@ from workbench.core.transforms.pandas_transforms.pandas_to_features_chunked impo
     PandasToFeaturesChunked,
 )
 from workbench.core.artifacts.data_source_factory import DataSourceFactory
+from workbench.utils.athena_utils import athena_output_s3_path
 
 
 class DataToFeaturesChunk(Transform):
@@ -83,6 +84,7 @@ class DataToFeaturesChunk(Transform):
             ctas_approach=False,
             chunksize=self.chunk_size,
             boto3_session=self.boto3_session,
+            s3_output=athena_output_s3_path(self.workbench_bucket),
         ):
             # Hand off each chunk of data
             self.chunked_to_features.add_chunk(chunk)

--- a/src/workbench/utils/athena_utils.py
+++ b/src/workbench/utils/athena_utils.py
@@ -2,8 +2,9 @@ import os
 import logging
 import boto3
 import time
-import pandas as pd
+
 import awswrangler as wr
+import pandas as pd
 
 # Workbench imports
 from workbench.utils.performance_utils import performance
@@ -11,6 +12,19 @@ from workbench.core.cloud_platform.aws.boto_session import get_boto3_session
 from workbench.core.parameter_store_core import ParameterStoreCore as ParameterStore
 
 log = logging.getLogger("workbench")
+
+
+def athena_output_s3_path(workbench_bucket: str = None) -> str:
+    """Get the S3 output path for Athena query results."""
+    if workbench_bucket is None:
+        param_key = "/workbench/config/workbench_bucket"
+        workbench_bucket = ParameterStore().get(param_key)
+        if workbench_bucket is None:
+            workbench_bucket = os.environ.get("WORKBENCH_BUCKET")
+            if workbench_bucket is None:
+                raise ValueError(f"Set '{param_key}' in Parameter Store or set WORKBENCH_BUCKET ENV variable.")
+
+    return f"s3://{workbench_bucket}/temp/athena_output"
 
 
 def table_s3_path(database: str, table_name: str) -> str:

--- a/tests/specific/athena_output_path_test.py
+++ b/tests/specific/athena_output_path_test.py
@@ -1,0 +1,71 @@
+"""Tests for Athena query output path configuration."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+class FakeParameterStore:
+    value = None
+
+    def get(self, key):
+        return self.value
+
+
+def load_athena_utils(monkeypatch):
+    """Load athena_utils with AWS/dataframe dependencies stubbed."""
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.session = types.SimpleNamespace(Session=object)
+    fake_pandas = types.ModuleType("pandas")
+    fake_pandas.DataFrame = object
+    fake_wr = types.ModuleType("awswrangler")
+    fake_wr.s3 = types.SimpleNamespace(delete_objects=lambda *args, **kwargs: None)
+
+    perf_module = types.ModuleType("workbench.utils.performance_utils")
+    perf_module.performance = lambda func: func
+    boto_session_module = types.ModuleType("workbench.core.cloud_platform.aws.boto_session")
+    boto_session_module.get_boto3_session = lambda: None
+    parameter_store_module = types.ModuleType("workbench.core.parameter_store_core")
+    parameter_store_module.ParameterStoreCore = FakeParameterStore
+
+    for name, module in {
+        "boto3": fake_boto3,
+        "pandas": fake_pandas,
+        "awswrangler": fake_wr,
+        "workbench.utils.performance_utils": perf_module,
+        "workbench.core.cloud_platform.aws.boto_session": boto_session_module,
+        "workbench.core.parameter_store_core": parameter_store_module,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_path = Path(__file__).resolve().parents[2] / "src" / "workbench" / "utils" / "athena_utils.py"
+    spec = importlib.util.spec_from_file_location("athena_utils_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_athena_output_s3_path_uses_explicit_bucket(monkeypatch):
+    athena_utils = load_athena_utils(monkeypatch)
+
+    assert athena_utils.athena_output_s3_path("test-bucket") == "s3://test-bucket/temp/athena_output"
+
+
+def test_athena_output_s3_path_falls_back_to_environment(monkeypatch):
+    FakeParameterStore.value = None
+    monkeypatch.setenv("WORKBENCH_BUCKET", "env-bucket")
+    athena_utils = load_athena_utils(monkeypatch)
+
+    assert athena_utils.athena_output_s3_path() == "s3://env-bucket/temp/athena_output"
+
+
+def test_athena_output_s3_path_requires_bucket(monkeypatch):
+    FakeParameterStore.value = None
+    monkeypatch.delenv("WORKBENCH_BUCKET", raising=False)
+    athena_utils = load_athena_utils(monkeypatch)
+
+    with pytest.raises(ValueError, match="WORKBENCH_BUCKET"):
+        athena_utils.athena_output_s3_path()


### PR DESCRIPTION
## Summary
- add a shared Athena query-result output path helper that uses the Workbench bucket
- pass the output path into awswrangler Athena query wrappers so newer awswrangler versions do not fall back to the default results bucket
- cover the helper with dependency-stubbed unit tests

Fixes #568.

## Tests
- $env:WORKBENCH_SKIP_LOGGING='true'; $env:PYTHONPATH='src'; py -m pytest tests\specific\athena_output_path_test.py -q --no-cov
- py -m py_compile src\workbench\utils\athena_utils.py src\workbench\core\artifacts\athena_source.py src\workbench\core\transforms\data_to_features\heavy\chunk\data_to_features_chunk.py src\workbench\api\inference_store.py tests\specific\athena_output_path_test.py
- py -m black --check --line-length=120 src\workbench\utils\athena_utils.py src\workbench\core\artifacts\athena_source.py src\workbench\core\transforms\data_to_features\heavy\chunk\data_to_features_chunk.py src\workbench\api\inference_store.py tests\specific\athena_output_path_test.py
- py -m flake8 src\workbench\utils\athena_utils.py src\workbench\core\artifacts\athena_source.py src\workbench\core\transforms\data_to_features\heavy\chunk\data_to_features_chunk.py src\workbench\api\inference_store.py tests\specific\athena_output_path_test.py
- git diff --check