### PR TITLE
Sync model page URL on selection

### DIFF
--- a/applications/aws_dashboard/pages/models/callbacks.py
+++ b/applications/aws_dashboard/pages/models/callbacks.py
@@ -3,12 +3,13 @@
 import logging
 from dash import callback, Input, Output, State
 from dash.exceptions import PreventUpdate
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 # Workbench Imports
 from workbench.web_interface.page_views.models_page_view import ModelsPageView
 from workbench.web_interface.components.plugins.ag_table import AGTable
 from workbench.cached.cached_model import CachedModel
+from .navigation import selected_model_url
 
 # Get the Workbench logger
 log = logging.getLogger("workbench")
@@ -60,6 +61,20 @@ def model_table_refresh(page_view: ModelsPageView, table: AGTable):
         models["name"] = models["Model Group"]
         models["id"] = range(len(models))
         return table.update_properties(models)
+
+
+def sync_selected_model_to_url():
+    @callback(
+        Output("url", "href", allow_duplicate=True),
+        Input("models_table", "selectedRows"),
+        State("url", "href"),
+        prevent_initial_call=True,
+    )
+    def _sync_selected_model_to_url(selected_rows, href):
+        updated_url = selected_model_url(selected_rows, href)
+        if updated_url is None:
+            raise PreventUpdate
+        return updated_url
 
 
 def setup_plugin_callbacks(plugins, model_details_plugin):

--- a/applications/aws_dashboard/pages/models/navigation.py
+++ b/applications/aws_dashboard/pages/models/navigation.py
@@ -1,0 +1,23 @@
+"""Navigation helpers for the models dashboard page."""
+
+from urllib.parse import parse_qs, urlencode, urlparse
+
+
+def selected_model_url(selected_rows, href):
+    """Return the canonical model page URL for the current table selection."""
+    if not selected_rows or selected_rows[0] is None:
+        return None
+
+    model_name = selected_rows[0].get("name")
+    if not model_name:
+        return None
+
+    parsed = urlparse(href or "/models")
+    if parsed.path != "/models":
+        return None
+
+    current_name = parse_qs(parsed.query).get("name", [None])[0]
+    if current_name == model_name:
+        return None
+
+    return f"/models?{urlencode({'name': model_name})}"

--- a/applications/aws_dashboard/pages/models/page.py
+++ b/applications/aws_dashboard/pages/models/page.py
@@ -49,6 +49,7 @@ model_view = ModelsPageView()
 
 # Callback for anything we want to happen on page load
 callbacks.on_page_load()
+callbacks.sync_selected_model_to_url()
 
 # Setup our callbacks/connections
 callbacks.model_table_refresh(model_view, models_table)

--- a/tests/specific/model_page_url_test.py
+++ b/tests/specific/model_page_url_test.py
@@ -1,0 +1,29 @@
+import pytest
+
+from applications.aws_dashboard.pages.models.navigation import selected_model_url
+
+
+def test_selected_model_url_updates_model_query_parameter():
+    selected_rows = [{"name": "demo-model-v2"}]
+
+    assert selected_model_url(selected_rows, "/models?name=demo-model-v1") == "/models?name=demo-model-v2"
+
+
+def test_selected_model_url_encodes_model_name():
+    selected_rows = [{"name": "demo model/v2"}]
+
+    assert selected_model_url(selected_rows, "/models") == "/models?name=demo+model%2Fv2"
+
+
+@pytest.mark.parametrize(
+    ("selected_rows", "href"),
+    [
+        ([], "/models?name=demo-model"),
+        ([None], "/models?name=demo-model"),
+        ([{}], "/models?name=demo-model"),
+        ([{"name": "demo-model"}], "/models?name=demo-model"),
+        ([{"name": "demo-model"}], "/feature_sets?name=demo-model"),
+    ],
+)
+def test_selected_model_url_prevents_unneeded_navigation(selected_rows, href):
+    assert selected_model_url(selected_rows, href) is None


### PR DESCRIPTION
## Summary
- update the Models page URL when a different model row is selected
- keep no-op navigation suppressed when the URL already matches the selected model or the current page is not /models
- add focused tests for URL generation and skip cases

Fixes #538.

## Validation
- py -m py_compile applications\\aws_dashboard\\pages\\models\\callbacks.py applications\\aws_dashboard\\pages\\models\\navigation.py applications\\aws_dashboard\\pages\\models\\page.py tests\\specific\\model_page_url_test.py
- py -m pytest tests\\specific\\model_page_url_test.py -q
- py -m black --target-version py313 --check applications\\aws_dashboard\\pages\\models\\callbacks.py applications\\aws_dashboard\\pages\\models\\navigation.py applications\\aws_dashboard\\pages\\models\\page.py tests\\specific\\model_page_url_test.py
- py -m flake8 applications\\aws_dashboard\\pages\\models\\callbacks.py applications\\aws_dashboard\\pages\\models\\navigation.py applications\\aws_dashboard\\pages\\models\\page.py tests\\specific\\model_page_url_test.py
- git diff --check