### PR TITLE
Expose DataSource input source setter

### DIFF
--- a/src/workbench/api/data_source.py
+++ b/src/workbench/api/data_source.py
@@ -5,17 +5,19 @@ techniques (data quality, distributions, stats, outliers, etc.) DataSources
 can be viewed and explored within the Workbench Dashboard UI."""
 
 import os
-import pandas as pd
 from typing import Union
+
+import pandas as pd
+
+from workbench.api.feature_set import FeatureSet
 
 # Workbench Imports
 from workbench.core.artifacts.artifact import Artifact
 from workbench.core.artifacts.athena_source import AthenaSource
 from workbench.core.transforms.data_loaders.light.csv_to_data_source import CSVToDataSource
 from workbench.core.transforms.data_loaders.light.s3_to_data_source_light import S3ToDataSourceLight
-from workbench.core.transforms.pandas_transforms.pandas_to_data import PandasToData
 from workbench.core.transforms.data_to_features.light.data_to_features_light import DataToFeaturesLight
-from workbench.api.feature_set import FeatureSet
+from workbench.core.transforms.pandas_transforms.pandas_to_data import PandasToData
 from workbench.utils.aws_utils import extract_data_source_basename
 
 
@@ -107,6 +109,18 @@ class DataSource(AthenaSource):
             df = df.drop(columns=aws_cols, errors="ignore")
         return df
 
+    def set_input(self, input_path: Union[str, os.PathLike]):
+        """Set the source path/reference recorded for this DataSource.
+
+        Args:
+            input_path (Union[str, os.PathLike]): Original local path, S3 URI, or other source reference.
+        """
+        input_reference = os.fspath(input_path)
+        if not input_reference:
+            raise ValueError("DataSource input path must not be empty")
+
+        super().set_input(input_reference)
+
     def to_features(
         self,
         name: str,
@@ -179,6 +193,7 @@ if __name__ == "__main__":
     import sys
     from pathlib import Path
     from pprint import pprint
+
     from workbench.utils.synthetic_data_generator import SyntheticDataGenerator
 
     # Test to Run

--- a/tests/specific/data_source_set_input_test.py
+++ b/tests/specific/data_source_set_input_test.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from workbench.api.data_source import DataSource
+
+
+class _LogRecorder:
+    def __init__(self):
+        self.messages = []
+
+    def important(self, message):
+        self.messages.append(message)
+
+
+def _data_source_double():
+    data_source = object.__new__(DataSource)
+    data_source.name = "sample_data"
+    data_source.log = _LogRecorder()
+    data_source.upserted_meta = []
+    data_source.upsert_workbench_meta = data_source.upserted_meta.append
+    return data_source
+
+
+def test_set_input_stores_s3_source_reference():
+    data_source = _data_source_double()
+
+    data_source.set_input("s3://bucket/raw/sample.csv")
+
+    assert data_source.upserted_meta == [{"workbench_input": "s3://bucket/raw/sample.csv"}]
+
+
+def test_set_input_accepts_pathlike_source_reference():
+    data_source = _data_source_double()
+    input_path = Path("raw") / "sample.csv"
+
+    data_source.set_input(input_path)
+
+    assert data_source.upserted_meta == [{"workbench_input": str(input_path)}]
+
+
+def test_set_input_rejects_empty_source_reference():
+    data_source = _data_source_double()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        data_source.set_input("")


### PR DESCRIPTION
## Summary
- add an explicit `DataSource.set_input()` API for recording the source path/reference after creating a DataSource
- accept local path-like values and S3/source URI strings through the existing Workbench metadata write path
- add focused coverage for S3 strings, `PathLike` inputs, and empty-reference rejection

Fixes #419.

## Validation
- `py -m py_compile src\\workbench\\api\\data_source.py tests\\specific\\data_source_set_input_test.py`
- `py -m black --target-version py313 --check src\\workbench\\api\\data_source.py tests\\specific\\data_source_set_input_test.py`
- `py -m flake8 src\\workbench\\api\\data_source.py tests\\specific\\data_source_set_input_test.py`
- `py -m isort --profile black --line-length 120 --check-only src\\workbench\\api\\data_source.py tests\\specific\\data_source_set_input_test.py`
- `git diff --check`

Targeted pytest could not be run in this local environment because the repo dependency `pandas` is not installed here (`ModuleNotFoundError: No module named 'pandas'` during collection).