### PR TITLE
Support PandasToFeatures constructor input options

### DIFF
--- a/docs/blogs/feature_endpoints.md
+++ b/docs/blogs/feature_endpoints.md
@@ -34,9 +34,12 @@ feature_endpoint = Endpoint("smiles-to-2d-v1")
 df_features = feature_endpoint.inference(df)
 
 # Create a FeatureSet and deploy a model that uses those features
-to_features = PandasToFeatures("open_admet_mppb")
-to_features.set_input(df_features, id_column="molecule_name")
-to_features.set_output_tags(["open_admet", assay])
+to_features = PandasToFeatures(
+    "open_admet_mppb",
+    input_df=df_features,
+    id_column="molecule_name",
+    tags=["open_admet", assay],
+)
 to_features.transform()
     
 # Now use the features to train a model as usual

--- a/src/workbench/core/transforms/pandas_transforms/pandas_to_features.py
+++ b/src/workbench/core/transforms/pandas_transforms/pandas_to_features.py
@@ -24,18 +24,34 @@ class PandasToFeatures(Transform):
 
     Common Usage:
         ```python
-        to_features = PandasToFeatures(output_name)
-        to_features.set_output_tags(["my", "awesome", "data"])
-        to_features.set_input(df, id_column="my_id")
+        to_features = PandasToFeatures(
+            output_name,
+            input_df=df,
+            id_column="my_id",
+            tags=["my", "awesome", "data"],
+        )
         to_features.transform()
         ```
     """
 
-    def __init__(self, output_name: str):
+    def __init__(
+        self,
+        output_name: str,
+        input_df: pd.DataFrame = None,
+        id_column=None,
+        tags=None,
+        event_time_column=None,
+        one_hot_columns=None,
+    ):
         """PandasToFeatures Initialization
 
         Args:
             output_name (str): The Name of the FeatureSet to create
+            input_df (pd.DataFrame, optional): The input DataFrame to prepare.
+            id_column (str, optional): The ID column for the input DataFrame.
+            tags (list | str, optional): Output tags to associate with the FeatureSet.
+            event_time_column (str, optional): The event time column for the input DataFrame.
+            one_hot_columns (list, optional): Columns to one-hot encode before ingest.
         """
 
         # Make sure the output_name is a valid name
@@ -58,6 +74,21 @@ class PandasToFeatures(Transform):
         self.output_feature_group = None
         self.output_feature_set = None
         self.expected_rows = 0
+
+        if tags is not None:
+            self.set_output_tags(tags)
+
+        input_options_provided = id_column is not None or event_time_column is not None or one_hot_columns is not None
+        if input_df is None and input_options_provided:
+            raise ValueError("input_df is required when id_column, event_time_column, or one_hot_columns are provided")
+
+        if input_df is not None:
+            self.set_input(
+                input_df,
+                id_column=id_column,
+                event_time_column=event_time_column,
+                one_hot_columns=one_hot_columns,
+            )
 
     def set_input(self, input_df: pd.DataFrame, id_column=None, event_time_column=None, one_hot_columns=None):
         """Set the Input DataFrame for this Transform

--- a/tests/specific/pandas_to_features_constructor_test.py
+++ b/tests/specific/pandas_to_features_constructor_test.py
@@ -1,0 +1,72 @@
+"""Tests for PandasToFeatures constructor input options."""
+
+import pandas as pd
+import pytest
+
+from workbench.core.transforms.pandas_transforms import PandasToFeatures
+from workbench.core.transforms import transform as transform_base
+
+
+class MockConfigManager:
+    """Minimal ConfigManager for constructor-only transform tests."""
+
+    def config_okay(self):
+        return True
+
+    def get_config(self, name):
+        return "workbench-test-bucket"
+
+
+class MockAWSSession:
+    """Minimal AWS session for constructor-only transform tests."""
+
+    def get_workbench_execution_role_arn(self):
+        return "arn:aws:iam::123456789012:role/workbench-test-role"
+
+
+class MockAWSAccountClamp:
+    """Minimal AWSAccountClamp for constructor-only transform tests."""
+
+    def __init__(self):
+        self.aws_session = MockAWSSession()
+        self.boto3_session = object()
+
+    def sagemaker_session(self):
+        return object()
+
+    def sagemaker_client(self):
+        return object()
+
+
+def test(monkeypatch):
+    """PandasToFeatures accepts input setup in the constructor."""
+    monkeypatch.setattr(transform_base, "ConfigManager", MockConfigManager)
+    monkeypatch.setattr(transform_base, "AWSAccountClamp", MockAWSAccountClamp)
+
+    df = pd.DataFrame(
+        {
+            "id": [1, 2],
+            "species": ["cat", "dog"],
+            "score": [1.5, 2.0],
+            "training": [True, False],
+        }
+    )
+
+    transform = PandasToFeatures(
+        "constructor_features",
+        input_df=df,
+        id_column="id",
+        tags=["test", "constructor"],
+        one_hot_columns=["species"],
+    )
+
+    assert transform.output_tags == "test::constructor"
+    assert transform.id_column == "id"
+    assert "event_time" in transform.output_df.columns
+    assert "training" not in transform.output_df.columns
+    assert "species_cat" in transform.output_df.columns
+    assert "species_dog" in transform.output_df.columns
+    assert "event_time" not in df.columns
+
+    with pytest.raises(ValueError, match="input_df is required"):
+        PandasToFeatures("missing_input", id_column="id")


### PR DESCRIPTION
## Summary
- add optional PandasToFeatures constructor arguments for DataFrame input, id column, tags, event time, and one-hot columns
- keep the existing set_input()/set_output_tags() workflow working
- update a docs example and add focused coverage for constructor-based setup

Fixes #495.

## Tests
- py -m py_compile src\workbench\core\transforms\pandas_transforms\pandas_to_features.py tests\specific\pandas_to_features_constructor_test.py
- py -m black --check --line-length=120 src\workbench\core\transforms\pandas_transforms\pandas_to_features.py tests\specific\pandas_to_features_constructor_test.py
- py -m flake8 src\workbench\core\transforms\pandas_transforms\pandas_to_features.py tests\specific\pandas_to_features_constructor_test.py
- git diff --check

Note: `py -m pytest tests\specific\pandas_to_features_constructor_test.py -q --no-cov` could not run in my local default Python environment because the project dependency stack is not installed there (`ModuleNotFoundError: No module named 'pandas'`).
