### PR TITLE
Reduce Parameter Store clipping for SHAP importance

### DIFF
--- a/src/workbench/core/parameter_store_core.py
+++ b/src/workbench/core/parameter_store_core.py
@@ -8,13 +8,14 @@ Endpoint code can instantiate ``ParameterStoreCore`` directly — it uses
 which short-circuits to the container's ambient IAM role in service envs.
 """
 
-from typing import Optional, Union
-import logging
-import json
-import zlib
-import time
 import base64
+import json
+import logging
+import time
+import zlib
 from datetime import datetime
+from typing import Optional, Union
+
 from botocore.exceptions import ClientError
 
 # Workbench Imports
@@ -139,7 +140,7 @@ class ParameterStoreCore:
         """
         try:
             # Convert to JSON and check if compression is needed
-            json_value = json.dumps(value, cls=CustomEncoder, precision=precision)
+            json_value = self._serialize_value(value, precision=precision)
             if len(json_value) <= 4096:
                 # Store normally if under 4KB
                 self._store_parameter(name, json_value)
@@ -150,20 +151,31 @@ class ParameterStoreCore:
                 f"Parameter {name} exceeds 4KB ({len(json_value)} bytes): compressing and reducing precision..."
             )
 
-            # Try compression with precision reduction
-            compressed_value = self._compress_value(value)
+            # Try compression with progressive precision reduction before clipping.
+            compressed_value = self._compress_value(value, precision=precision)
 
             if len(compressed_value) <= 4096:
                 self._store_parameter(name, compressed_value)
                 return
 
+            for reduced_precision in self._reduced_precision_steps(precision):
+                compressed_value = self._compress_value(value, precision=reduced_precision)
+                if len(compressed_value) <= 4096:
+                    self.log.warning(
+                        f"Parameter {name} stored with float precision={reduced_precision} "
+                        f"to stay within 4KB ({len(compressed_value)} bytes)"
+                    )
+                    self._store_parameter(name, compressed_value)
+                    return
+
             # Try clipping the data
             clipped_value = self._clip_data(value)
-            compressed_clipped = self._compress_value(clipped_value)
+            compressed_clipped = self._compress_value(clipped_value, precision=0)
 
             if len(compressed_clipped) <= 4096:
                 self.log.warning(
-                    f"Parameter {name} data clipped to 100 items/elements: ({len(compressed_clipped)} bytes)"
+                    f"Parameter {name} data clipped to 100 items/elements after precision reduction: "
+                    f"({len(compressed_clipped)} bytes)"
                 )
                 self._store_parameter(name, compressed_clipped)
                 return
@@ -191,11 +203,25 @@ class ParameterStoreCore:
                     raise
 
     @staticmethod
-    def _compress_value(value) -> str:
+    def _serialize_value(value, precision: int = None) -> str:
+        """Serialize values compactly for Parameter Store's 4KB limit."""
+        return json.dumps(value, cls=CustomEncoder, precision=precision, separators=(",", ":"))
+
+    @classmethod
+    def _compress_value(cls, value, precision: int = 3) -> str:
         """Compress a value with precision reduction."""
-        json_value = json.dumps(value, cls=CustomEncoder, precision=3)
+        json_value = cls._serialize_value(value, precision=precision)
         compressed = zlib.compress(json_value.encode("utf-8"), level=9)
         return "COMPRESSED:" + base64.b64encode(compressed).decode("utf-8")
+
+    @staticmethod
+    def _reduced_precision_steps(precision: int):
+        """Return lower precision candidates, avoiding duplicates."""
+        try:
+            precision = int(precision)
+        except (TypeError, ValueError):
+            precision = 3
+        return range(max(precision - 1, 0), -1, -1)
 
     @staticmethod
     def _clip_data(value):

--- a/src/workbench/utils/json_utils.py
+++ b/src/workbench/utils/json_utils.py
@@ -1,14 +1,18 @@
 """JSON Utilities"""
 
 import json
+import logging
+from datetime import date, datetime
 from io import StringIO
+
 import numpy as np
 import pandas as pd
-import logging
-from datetime import datetime, date
 
 # Local Imports
-from workbench.utils.datetime_utils import datetime_to_iso8601, iso8601_to_datetime
+from workbench.utils.datetime_utils import (
+    datetime_to_iso8601,
+    iso8601_to_datetime,
+)
 
 log = logging.getLogger("workbench")
 
@@ -47,10 +51,10 @@ class CustomEncoder(json.JSONEncoder):
             return super().default(obj)
 
     def encode(self, obj):
-        return super().encode(self._reduce_precision(obj) if self.precision else obj)
+        return super().encode(self._reduce_precision(obj) if self.precision is not None else obj)
 
     def _reduce_precision(self, obj):
-        if isinstance(obj, float):
+        if isinstance(obj, (float, np.floating)):
             return round(obj, self.precision)
         elif isinstance(obj, dict):
             return {k: self._reduce_precision(v) for k, v in obj.items()}

--- a/tests/specific/parameter_store_precision_test.py
+++ b/tests/specific/parameter_store_precision_test.py
@@ -1,0 +1,34 @@
+"""Tests for compact Parameter Store serialization."""
+
+import base64
+import json
+import zlib
+
+from workbench.core.parameter_store_core import ParameterStoreCore
+
+
+def _decode_compressed(value):
+    payload = value[len("COMPRESSED:") :]
+    return json.loads(zlib.decompress(base64.b64decode(payload)).decode("utf-8"))
+
+
+def test_zero_precision_compression_rounds_float_values():
+    value = [("feature_a", 0.0275759007781744), ("feature_b", 0.9999)]
+
+    compressed = ParameterStoreCore._compress_value(value, precision=0)
+    decoded = _decode_compressed(compressed)
+
+    assert decoded == [["feature_a", 0.0], ["feature_b", 1.0]]
+
+
+def test_progressive_precision_preserves_all_items_before_clipping():
+    value = [(f"feature_{i:03d}", i / 123456.789) for i in range(350)]
+
+    lower_precision_sizes = [
+        len(ParameterStoreCore._compress_value(value, precision=precision))
+        for precision in ParameterStoreCore._reduced_precision_steps(3)
+    ]
+    clipped = _decode_compressed(ParameterStoreCore._compress_value(ParameterStoreCore._clip_data(value), precision=0))
+
+    assert len(clipped) == 100
+    assert any(size <= 4096 for size in lower_precision_sizes)


### PR DESCRIPTION
## Summary
- serialize Parameter Store values compactly before checking the 4KB limit
- try progressively lower float precision before falling back to clipping list/dict data to 100 items
- support zero-decimal precision reduction, including numpy floating values, so SHAP-style importance lists can retain more entries

Fixes #531.

## Validation
- py -m py_compile src\\workbench\\core\\parameter_store_core.py src\\workbench\\utils\\json_utils.py tests\\specific\\parameter_store_precision_test.py
- py -m black --target-version py313 --check --line-length=120 src\\workbench\\core\\parameter_store_core.py src\\workbench\\utils\\json_utils.py tests\\specific\\parameter_store_precision_test.py
- py -m flake8 src\\workbench\\core\\parameter_store_core.py src\\workbench\\utils\\json_utils.py tests\\specific\\parameter_store_precision_test.py
- py -m isort --profile black --line-length 120 --check src\\workbench\\core\\parameter_store_core.py src\\workbench\\utils\\json_utils.py tests\\specific\\parameter_store_precision_test.py
- git diff --check

Focused pytest note: local PYTHONPATH=src py -m pytest tests\\specific\\parameter_store_precision_test.py -q --no-cov is blocked in this clean interpreter by missing optional project dependencies (otocore / pandas).