### PR TITLE
Store classifier labels in model metadata

### DIFF
--- a/src/workbench/core/artifacts/model_core.py
+++ b/src/workbench/core/artifacts/model_core.py
@@ -1,30 +1,33 @@
 """ModelCore: Workbench ModelCore Class"""
 
 import time
-from datetime import datetime
 import urllib.parse
-from typing import Union, Optional, List, Dict, Tuple
+from datetime import datetime
 from enum import Enum
-import botocore
-from botocore.exceptions import ClientError
-
-import pandas as pd
-import awswrangler as wr
+from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
+
+import awswrangler as wr
+import botocore
+import pandas as pd
 from awswrangler.exceptions import NoFilesFound
+from botocore.exceptions import ClientError
 from sagemaker.core.resources import (
-    TrainingJob,
     ModelPackageGroup,
+    TrainingJob,
 )
 
 # Workbench Imports
 from workbench.core.artifacts.artifact import Artifact
 from workbench.utils.aws_utils import newest_path, pull_s3_data
-from workbench.utils.metrics_utils import reorder_cm_df, reorder_metrics_df
-from workbench.utils.s3_utils import compute_s3_object_hash
-from workbench.utils.shap_utils import get_shap_importance, get_shap_values, get_shap_feature_values
 from workbench.utils.deprecated_utils import deprecated
-from workbench.utils.model_utils import published_proximity_model, get_model_hyperparameters
+from workbench.utils.metrics_utils import reorder_cm_df, reorder_metrics_df
+from workbench.utils.model_utils import get_model_hyperparameters, published_proximity_model
+from workbench.utils.s3_utils import compute_s3_object_hash
+from workbench.utils.shap_utils import get_shap_feature_values, get_shap_importance, get_shap_values
+
+CLASS_LABELS_META_KEY = "workbench_model_labels"
+LEGACY_CLASS_LABELS_META_KEY = "class_labels"
 
 
 class ModelType(Enum):
@@ -556,11 +559,20 @@ class ModelCore(Artifact):
             list[str]: List of class labels
         """
         if self.model_type == ModelType.CLASSIFIER:
-            return self.workbench_meta().get("class_labels")  # Returns None if not found
+            metadata = self.workbench_meta()
+            labels = metadata.get(CLASS_LABELS_META_KEY)
+            return labels if labels is not None else metadata.get(LEGACY_CLASS_LABELS_META_KEY)
         else:
             return None
 
-    def set_class_labels(self, labels: list[str]):
+    def labels(self) -> Union[list[str], None]:
+        """Return the class labels for this Model.
+
+        This is the public shorthand API for retrieving classification labels.
+        """
+        return self.class_labels()
+
+    def set_class_labels(self, labels: Optional[list[str]]):
         """Set the class labels for this Model (if it's a classifier)
 
         Also reorders existing inference artifacts (confusion matrix and inference
@@ -575,7 +587,10 @@ class ModelCore(Artifact):
             self.log.error(f"Model {self.model_name} is not a classifier!")
             return
 
-        self.upsert_workbench_meta({"class_labels": labels})
+        labels = list(labels) if labels else None
+        self.upsert_workbench_meta({CLASS_LABELS_META_KEY: labels, LEGACY_CLASS_LABELS_META_KEY: labels})
+        if labels is None:
+            return
         self._reorder_class_artifacts(labels)
 
     def _reorder_class_artifacts(self, labels: list[str]):
@@ -679,6 +694,7 @@ class ModelCore(Artifact):
         details = self.summary()
         details["pipeline"] = self.get_pipeline()
         details["model_type"] = self.model_type.value
+        details["labels"] = self.labels()
         details["model_package_group_arn"] = self.group_arn()
         details["model_package_arn"] = self.model_package_arn()
 

--- a/tests/specific/model_labels_test.py
+++ b/tests/specific/model_labels_test.py
@@ -1,0 +1,146 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def install_module(name, **attrs):
+    module = ModuleType(name)
+    for attr_name, value in attrs.items():
+        setattr(module, attr_name, value)
+    sys.modules[name] = module
+    return module
+
+
+def load_model_core_module():
+    stub_names = [
+        "botocore",
+        "botocore.exceptions",
+        "pandas",
+        "awswrangler",
+        "awswrangler.exceptions",
+        "sagemaker",
+        "sagemaker.core",
+        "sagemaker.core.resources",
+        "workbench",
+        "workbench.core",
+        "workbench.core.artifacts",
+        "workbench.core.artifacts.artifact",
+        "workbench.utils",
+        "workbench.utils.aws_utils",
+        "workbench.utils.metrics_utils",
+        "workbench.utils.s3_utils",
+        "workbench.utils.shap_utils",
+        "workbench.utils.deprecated_utils",
+        "workbench.utils.model_utils",
+    ]
+    missing = object()
+    original_modules = {name: sys.modules.get(name, missing) for name in stub_names}
+
+    class ClientError(Exception):
+        pass
+
+    class Artifact:
+        pass
+
+    def identity_decorator(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    exceptions = SimpleNamespace(ClientError=ClientError, NoFilesFound=type("NoFilesFound", (Exception,), {}))
+    botocore = install_module("botocore", exceptions=exceptions)
+    install_module("botocore.exceptions", ClientError=ClientError)
+    install_module("pandas", DataFrame=lambda *args, **kwargs: None)
+    install_module("awswrangler", s3=SimpleNamespace())
+    install_module("awswrangler.exceptions", NoFilesFound=exceptions.NoFilesFound)
+    install_module("sagemaker", core=SimpleNamespace())
+    install_module("sagemaker.core", resources=SimpleNamespace(), shapes=SimpleNamespace())
+    install_module("sagemaker.core.resources", TrainingJob=object, ModelPackageGroup=object)
+    install_module("workbench")
+    install_module("workbench.core")
+    install_module("workbench.core.artifacts")
+    install_module("workbench.core.artifacts.artifact", Artifact=Artifact)
+    install_module("workbench.utils")
+    install_module(
+        "workbench.utils.aws_utils", newest_path=lambda *args, **kwargs: None, pull_s3_data=lambda *a, **k: None
+    )
+    install_module(
+        "workbench.utils.metrics_utils", reorder_cm_df=lambda df, labels: df, reorder_metrics_df=lambda df, labels: df
+    )
+    install_module("workbench.utils.s3_utils", compute_s3_object_hash=lambda *args, **kwargs: None)
+    install_module(
+        "workbench.utils.shap_utils",
+        get_shap_importance=lambda *a, **k: None,
+        get_shap_values=lambda *a, **k: None,
+        get_shap_feature_values=lambda *a, **k: None,
+    )
+    install_module("workbench.utils.deprecated_utils", deprecated=identity_decorator)
+    install_module(
+        "workbench.utils.model_utils",
+        published_proximity_model=lambda *a, **k: None,
+        get_model_hyperparameters=lambda *a, **k: None,
+    )
+
+    model_core_path = Path(__file__).parents[2] / "src" / "workbench" / "core" / "artifacts" / "model_core.py"
+    spec = importlib.util.spec_from_file_location("model_core_under_test", model_core_path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+        assert sys.modules["botocore"] is botocore
+    finally:
+        for name, original in original_modules.items():
+            if original is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+    return module
+
+
+MODEL_CORE = load_model_core_module()
+CLASS_LABELS_META_KEY = MODEL_CORE.CLASS_LABELS_META_KEY
+LEGACY_CLASS_LABELS_META_KEY = MODEL_CORE.LEGACY_CLASS_LABELS_META_KEY
+ModelCore = MODEL_CORE.ModelCore
+ModelType = MODEL_CORE.ModelType
+
+
+def model_core_stub(model_type=ModelType.CLASSIFIER, metadata=None):
+    model = object.__new__(ModelCore)
+    model.model_type = model_type
+    model.model_name = "test-model"
+    model.log = SimpleNamespace(error=lambda *args, **kwargs: None)
+    model._metadata = {} if metadata is None else dict(metadata)
+    model._reorder_calls = []
+    model.workbench_meta = lambda: model._metadata
+    model.upsert_workbench_meta = lambda updates: model._metadata.update(updates)
+    model._reorder_class_artifacts = lambda labels: model._reorder_calls.append(labels)
+    return model
+
+
+def test_set_class_labels_updates_new_and_legacy_metadata():
+    model = model_core_stub()
+
+    model.set_class_labels(["low", "medium", "high"])
+
+    assert model.workbench_meta()[CLASS_LABELS_META_KEY] == ["low", "medium", "high"]
+    assert model.workbench_meta()[LEGACY_CLASS_LABELS_META_KEY] == ["low", "medium", "high"]
+    assert model.class_labels() == ["low", "medium", "high"]
+    assert model.labels() == ["low", "medium", "high"]
+    assert model._reorder_calls == [["low", "medium", "high"]]
+
+
+def test_labels_reads_legacy_metadata_for_existing_models():
+    model = model_core_stub(metadata={LEGACY_CLASS_LABELS_META_KEY: ["spam", "ham"]})
+
+    assert model.labels() == ["spam", "ham"]
+
+
+def test_labels_are_classifier_only():
+    model = model_core_stub(model_type=ModelType.REGRESSOR)
+
+    model.set_class_labels(["ignored"])
+
+    assert model.labels() is None
+    assert CLASS_LABELS_META_KEY not in model.workbench_meta()
+    assert LEGACY_CLASS_LABELS_META_KEY not in model.workbench_meta()


### PR DESCRIPTION
## Summary
- add a public Model.labels() shorthand for retrieving classifier labels
- store classifier labels under workbench_model_labels while keeping the legacy class_labels key in sync
- include labels in model details and preserve legacy metadata fallback
- add focused tests for label metadata storage, legacy reads, and non-classifier behavior

Fixes #417.

## Validation
- py -m py_compile src\\workbench\\core\\artifacts\\model_core.py tests\\specific\\model_labels_test.py
- py -m black --target-version py313 --check --line-length=120 src\\workbench\\core\\artifacts\\model_core.py tests\\specific\\model_labels_test.py
- py -m flake8 src\\workbench\\core\\artifacts\\model_core.py tests\\specific\\model_labels_test.py
- py -m isort --profile black --line-length 120 --check src\\workbench\\core\\artifacts\\model_core.py tests\\specific\\model_labels_test.py
- PYTHONPATH=src py -m pytest tests\\specific\\model_labels_test.py -q --no-cov
- git diff --check
