### PR TITLE
Flatten regression training metrics metadata

### DIFF
--- a/src/workbench/core/artifacts/model_core.py
+++ b/src/workbench/core/artifacts/model_core.py
@@ -1,30 +1,30 @@
 """ModelCore: Workbench ModelCore Class"""
 
 import time
-from datetime import datetime
 import urllib.parse
-from typing import Union, Optional, List, Dict, Tuple
+from datetime import datetime
 from enum import Enum
-import botocore
-from botocore.exceptions import ClientError
-
-import pandas as pd
-import awswrangler as wr
+from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
+
+import awswrangler as wr
+import botocore
+import pandas as pd
 from awswrangler.exceptions import NoFilesFound
+from botocore.exceptions import ClientError
 from sagemaker.core.resources import (
-    TrainingJob,
     ModelPackageGroup,
+    TrainingJob,
 )
 
 # Workbench Imports
 from workbench.core.artifacts.artifact import Artifact
 from workbench.utils.aws_utils import newest_path, pull_s3_data
-from workbench.utils.metrics_utils import reorder_cm_df, reorder_metrics_df
-from workbench.utils.s3_utils import compute_s3_object_hash
-from workbench.utils.shap_utils import get_shap_importance, get_shap_values, get_shap_feature_values
 from workbench.utils.deprecated_utils import deprecated
-from workbench.utils.model_utils import published_proximity_model, get_model_hyperparameters
+from workbench.utils.metrics_utils import reorder_cm_df, reorder_metrics_df
+from workbench.utils.model_utils import get_model_hyperparameters, published_proximity_model
+from workbench.utils.s3_utils import compute_s3_object_hash
+from workbench.utils.shap_utils import get_shap_feature_values, get_shap_importance, get_shap_values
 
 
 class ModelType(Enum):
@@ -100,6 +100,29 @@ class ModelCore(Artifact):
         my_model.details()
         ```
     """
+
+    @staticmethod
+    def _is_flat_training_metrics(metrics: dict) -> bool:
+        """Return True when training metrics are stored as a simple metric/value mapping."""
+        return (
+            isinstance(metrics, dict)
+            and bool(metrics)
+            and all(not isinstance(value, dict) for value in metrics.values())
+        )
+
+    @staticmethod
+    def _training_metrics_from_metadata(metrics: dict) -> pd.DataFrame:
+        """Convert model-training metrics metadata into the public DataFrame shape."""
+        if ModelCore._is_flat_training_metrics(metrics):
+            return pd.DataFrame([metrics])
+        return pd.DataFrame.from_dict(metrics)
+
+    @staticmethod
+    def _regression_training_metrics_metadata(metrics_df: pd.DataFrame) -> dict:
+        """Serialize regression training metrics as a compact metric/value mapping."""
+        if {"metric_name", "value"}.issubset(metrics_df.columns):
+            return dict(zip(metrics_df["metric_name"], metrics_df["value"]))
+        return metrics_df.to_dict()
 
     def __init__(self, model_name: str, **kwargs):
         """ModelCore Initialization
@@ -319,7 +342,7 @@ class ModelCore(Artifact):
                 raise ValueError(error_msg)
 
             metrics = self.workbench_meta().get("workbench_training_metrics")
-            return pd.DataFrame.from_dict(metrics) if metrics else None
+            return self._training_metrics_from_metadata(metrics) if metrics else None
 
         else:  # Specific capture_name (could return None)
             s3_path = f"{self.endpoint_inference_path}/{capture_name}/inference_metrics.csv"
@@ -649,8 +672,8 @@ class ModelCore(Artifact):
                 self.log.warning("Skipping training CM reorder: labels do not match new label set")
 
         metrics_dict = meta.get("workbench_training_metrics")
-        if metrics_dict:
-            metrics = pd.DataFrame.from_dict(metrics_dict)
+        if metrics_dict and not self._is_flat_training_metrics(metrics_dict):
+            metrics = self._training_metrics_from_metadata(metrics_dict)
             reordered = reorder_metrics_df(metrics, labels)
             if reordered is not None:
                 self.upsert_workbench_meta({"workbench_training_metrics": reordered.to_dict()})
@@ -1154,16 +1177,8 @@ class ModelCore(Artifact):
                 self.upsert_workbench_meta({"workbench_training_metrics": None, "workbench_training_cm": None})
                 return
             if self.model_type in [ModelType.REGRESSOR, ModelType.UQ_REGRESSOR, ModelType.ENSEMBLE_REGRESSOR]:
-                if "timestamp" in df.columns:
-                    df = df.drop(columns=["timestamp"])
-
-                # We're going to pivot the DataFrame to get the desired structure
-                reg_metrics_df = df.set_index("metric_name").T
-
-                # Store and return the metrics in the Workbench Metadata
-                self.upsert_workbench_meta(
-                    {"workbench_training_metrics": reg_metrics_df.to_dict(), "workbench_training_cm": None}
-                )
+                reg_metrics = self._regression_training_metrics_metadata(df)
+                self.upsert_workbench_meta({"workbench_training_metrics": reg_metrics, "workbench_training_cm": None})
                 return
 
         except (KeyError, botocore.exceptions.ClientError):

--- a/tests/specific/model_training_metrics_metadata_test.py
+++ b/tests/specific/model_training_metrics_metadata_test.py
@@ -1,0 +1,142 @@
+"""Tests for model-training metrics metadata serialization."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class FakeMetricsFrame:
+    """Small DataFrame stand-in for regression metrics serialization tests."""
+
+    columns = ["metric_name", "value", "timestamp"]
+
+    def __getitem__(self, key):
+        data = {
+            "metric_name": ["MAE", "RMSE", "R2"],
+            "value": [0.77, 1.28, 0.84],
+            "timestamp": ["unused", "unused", "unused"],
+        }
+        return data[key]
+
+
+def _load_model_core_module():
+    module_names = [
+        "botocore",
+        "botocore.exceptions",
+        "awswrangler",
+        "awswrangler.exceptions",
+        "sagemaker",
+        "sagemaker.core",
+        "sagemaker.core.resources",
+        "workbench",
+        "workbench.core",
+        "workbench.core.artifacts",
+        "workbench.core.artifacts.artifact",
+        "workbench.utils",
+        "workbench.utils.aws_utils",
+        "workbench.utils.metrics_utils",
+        "workbench.utils.s3_utils",
+        "workbench.utils.shap_utils",
+        "workbench.utils.deprecated_utils",
+        "workbench.utils.model_utils",
+    ]
+    originals = {name: sys.modules.get(name) for name in module_names}
+
+    class FakeDataFrame:
+        def __init__(self, data=None):
+            self.data = data
+            self.from_dict_input = None
+
+        @classmethod
+        def from_dict(cls, data):
+            instance = cls()
+            instance.from_dict_input = data
+            return instance
+
+    class FakeClientError(Exception):
+        pass
+
+    def module(name, **attrs):
+        mod = types.ModuleType(name)
+        for attr_name, value in attrs.items():
+            setattr(mod, attr_name, value)
+        sys.modules[name] = mod
+        return mod
+
+    try:
+        pandas = module("pandas", DataFrame=FakeDataFrame)
+        exceptions = module("botocore.exceptions", ClientError=FakeClientError)
+        module("botocore", exceptions=exceptions)
+        wr_exceptions = module("awswrangler.exceptions", NoFilesFound=Exception)
+        module("awswrangler", exceptions=wr_exceptions)
+        module("sagemaker")
+        module("sagemaker.core")
+        module("sagemaker.core.resources", TrainingJob=object, ModelPackageGroup=object)
+        module("workbench")
+        module("workbench.core")
+        module("workbench.core.artifacts")
+        module("workbench.core.artifacts.artifact", Artifact=object)
+        module("workbench.utils")
+        module("workbench.utils.aws_utils", newest_path=lambda *args, **kwargs: None, pull_s3_data=lambda *args: None)
+        module(
+            "workbench.utils.metrics_utils",
+            reorder_cm_df=lambda *args, **kwargs: None,
+            reorder_metrics_df=lambda *args, **kwargs: None,
+        )
+        module("workbench.utils.s3_utils", compute_s3_object_hash=lambda *args, **kwargs: None)
+        module(
+            "workbench.utils.shap_utils",
+            get_shap_importance=lambda *args, **kwargs: None,
+            get_shap_values=lambda *args, **kwargs: None,
+            get_shap_feature_values=lambda *args, **kwargs: None,
+        )
+        module("workbench.utils.deprecated_utils", deprecated=lambda *args, **kwargs: (lambda func: func))
+        module(
+            "workbench.utils.model_utils",
+            published_proximity_model=lambda *args, **kwargs: None,
+            get_model_hyperparameters=lambda *args, **kwargs: None,
+        )
+
+        module_path = Path(__file__).parents[2] / "src" / "workbench" / "core" / "artifacts" / "model_core.py"
+        spec = importlib.util.spec_from_file_location("model_core_under_test", module_path)
+        model_core = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(model_core)
+        model_core.pd = pandas
+        return model_core
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def test_regression_training_metrics_are_flat_metadata():
+    model_core = _load_model_core_module()
+
+    assert model_core.ModelCore._regression_training_metrics_metadata(FakeMetricsFrame()) == {
+        "MAE": 0.77,
+        "RMSE": 1.28,
+        "R2": 0.84,
+    }
+
+
+def test_flat_training_metrics_metadata_reads_as_single_row_dataframe():
+    model_core = _load_model_core_module()
+    flat_metrics = {"MAE": 0.77, "RMSE": 1.28}
+
+    metrics_df = model_core.ModelCore._training_metrics_from_metadata(flat_metrics)
+
+    assert metrics_df.data == [flat_metrics]
+    assert metrics_df.from_dict_input is None
+
+
+def test_nested_training_metrics_metadata_keeps_legacy_reader():
+    model_core = _load_model_core_module()
+    legacy_metrics = {"MAE": {"0": 0.77}, "RMSE": {"0": 1.28}}
+
+    metrics_df = model_core.ModelCore._training_metrics_from_metadata(legacy_metrics)
+
+    assert metrics_df.data is None
+    assert metrics_df.from_dict_input == legacy_metrics


### PR DESCRIPTION
## Summary
- Store regression model-training metrics as a flat metric/value dictionary in Workbench metadata instead of the nested single-row DataFrame dict form.
- Keep `get_inference_metrics("model_training")` backward-compatible with existing nested metadata while reading the new flat format as a one-row DataFrame.
- Avoid trying to reorder already-flat regression metrics metadata when class labels are reordered.
- Add focused dependency-light tests for flat serialization and legacy nested reads.

Fixes #410.

## Validation
- `py -m py_compile src\workbench\core\artifacts\model_core.py tests\specific\model_training_metrics_metadata_test.py`
- `py -m pytest tests\specific\model_training_metrics_metadata_test.py -q --no-cov`
- `py -m black --target-version py313 --check --line-length=120 src\workbench\core\artifacts\model_core.py tests\specific\model_training_metrics_metadata_test.py`
- `py -m flake8 src\workbench\core\artifacts\model_core.py tests\specific\model_training_metrics_metadata_test.py`
- `py -m isort --profile black --line-length 120 --check src\workbench\core\artifacts\model_core.py tests\specific\model_training_metrics_metadata_test.py`
- `git diff --cached --check`