### PR TITLE
Support categorical features in proximity models

### DIFF
--- a/src/workbench/algorithms/dataframe/feature_space_proximity.py
+++ b/src/workbench/algorithms/dataframe/feature_space_proximity.py
@@ -1,13 +1,15 @@
-import pandas as pd
-import numpy as np
-from sklearn.preprocessing import StandardScaler
-from sklearn.neighbors import NearestNeighbors
-from typing import List, Optional
 import logging
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.neighbors import NearestNeighbors
+from sklearn.preprocessing import StandardScaler
+
+from workbench.algorithms.dataframe.projection_2d import Projection2D
 
 # Workbench Imports
 from workbench.algorithms.dataframe.proximity import Proximity
-from workbench.algorithms.dataframe.projection_2d import Projection2D
 
 # Set up logging
 log = logging.getLogger("workbench")
@@ -49,21 +51,68 @@ class FeatureSpaceProximity(Proximity):
         )
 
     def _prepare_data(self) -> None:
-        """Filter out non-numeric features and drop NaN rows."""
+        """Filter unsupported features, encode categoricals, and drop NaN rows."""
         self.features = self._validate_features(self.df, self._raw_features)
+        self._numeric_features = [
+            feature for feature in self.features if pd.api.types.is_numeric_dtype(self.df[feature])
+        ]
+        self._categorical_features = [
+            feature for feature in self.features if self._is_categorical_feature(self.df[feature])
+        ]
         self.df = self.df.dropna(subset=self.features).copy()
+        self._encoded_reference = self._encode_feature_frame(self.df, fit=True)
 
     def _validate_features(self, df: pd.DataFrame, features: List[str]) -> List[str]:
-        """Remove non-numeric features and log warnings."""
-        non_numeric = [f for f in features if f not in df.select_dtypes(include=["number"]).columns]
-        if non_numeric:
-            log.warning(f"Non-numeric features {non_numeric} aren't currently supported, excluding them")
-        return [f for f in features if f not in non_numeric]
+        """Remove unsupported features and log warnings."""
+        supported = []
+        unsupported = []
+        missing = [feature for feature in features if feature not in df.columns]
+
+        for feature in features:
+            if feature not in df.columns:
+                continue
+            if pd.api.types.is_numeric_dtype(df[feature]) or self._is_categorical_feature(df[feature]):
+                supported.append(feature)
+            else:
+                unsupported.append(feature)
+
+        if missing:
+            log.warning(f"Features {missing} are missing from the DataFrame, excluding them")
+        if unsupported:
+            log.warning(f"Features {unsupported} have unsupported types, excluding them")
+        if not supported:
+            raise ValueError("No supported features remain for FeatureSpaceProximity")
+        return supported
+
+    @staticmethod
+    def _is_categorical_feature(series: pd.Series) -> bool:
+        """Return True for feature types that should be one-hot encoded."""
+        return (
+            str(series.dtype) == "category"
+            or pd.api.types.is_object_dtype(series)
+            or pd.api.types.is_string_dtype(series)
+            or pd.api.types.is_bool_dtype(series)
+        )
+
+    def _encode_feature_frame(self, df: pd.DataFrame, fit: bool = False) -> pd.DataFrame:
+        """Convert the original feature columns into the numeric matrix used by the NN model."""
+        missing = [feature for feature in self.features if feature not in df.columns]
+        if missing:
+            raise ValueError(f"Query DataFrame is missing proximity features: {missing}")
+
+        feature_df = df[self.features].copy()
+        if self._categorical_features:
+            feature_df = pd.get_dummies(feature_df, columns=self._categorical_features, dtype=float)
+
+        if fit:
+            self._encoded_features = feature_df.columns.tolist()
+            return feature_df
+        return feature_df.reindex(columns=self._encoded_features, fill_value=0.0)
 
     def _build_model(self) -> None:
         """Standardize features and fit Nearest Neighbors model."""
         self.scaler = StandardScaler()
-        X = self.scaler.fit_transform(self.df[self.features])
+        X = self.scaler.fit_transform(self._encoded_reference)
         self.nn = NearestNeighbors().fit(X)
 
     def _transform_features(self, df: pd.DataFrame) -> np.ndarray:
@@ -72,15 +121,19 @@ class FeatureSpaceProximity(Proximity):
         For novel-input queries via `neighbors_from_query_df`, the query DataFrame
         must contain the same feature columns this model was built with.
         """
-        return self.scaler.transform(df[self.features])
+        return self.scaler.transform(self._encode_feature_frame(df))
 
     def project_2d(self) -> pd.DataFrame:
         """Project the numeric features to 2D for visualization (UMAP).
 
         Returns the reference DataFrame with 'x' / 'y' columns added.
         """
-        if len(self.features) >= 2:
-            self.df = Projection2D().fit_transform(self.df, features=self.features)
+        if len(self._encoded_features) >= 2:
+            projection_df = self._encoded_reference.copy()
+            projection_df[self.id_column] = self.df[self.id_column].values
+            projection_df = Projection2D().fit_transform(projection_df, features=self._encoded_features)
+            self.df["x"] = projection_df["x"].values
+            self.df["y"] = projection_df["y"].values
         return self.df
 
 

--- a/tests/specific/feature_space_proximity_categorical_test.py
+++ b/tests/specific/feature_space_proximity_categorical_test.py
@@ -1,0 +1,55 @@
+"""Tests for categorical feature support in FeatureSpaceProximity."""
+
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("pandas") is None or importlib.util.find_spec("sklearn") is None,
+    reason="pandas and scikit-learn are required for FeatureSpaceProximity tests",
+)
+
+
+def _test_deps():
+    import pandas as pd
+
+    from workbench.algorithms.dataframe.feature_space_proximity import FeatureSpaceProximity
+
+    return pd, FeatureSpaceProximity
+
+
+def test_categorical_feature_affects_neighbors():
+    pd, FeatureSpaceProximity = _test_deps()
+    df = pd.DataFrame(
+        {
+            "id": ["red-near", "blue-near", "red-far"],
+            "size": [1.0, 1.0, 10.0],
+            "color": ["red", "blue", "red"],
+            "target": [0, 1, 2],
+        }
+    )
+
+    prox = FeatureSpaceProximity(df, id_column="id", features=["size", "color"], target="target")
+    neighbors = prox.neighbors_from_query_df(pd.DataFrame({"size": [1.0], "color": ["blue"]}), n_neighbors=1)
+
+    assert {"color_blue", "color_red"}.issubset(prox._encoded_features)
+    assert neighbors.loc[0, "neighbor_id"] == "blue-near"
+    assert neighbors.loc[0, "distance"] == 0.0
+
+
+def test_unseen_query_category_aligns_to_training_columns():
+    pd, FeatureSpaceProximity = _test_deps()
+    df = pd.DataFrame(
+        {
+            "id": ["a", "b"],
+            "size": [1.0, 2.0],
+            "color": ["red", "blue"],
+        }
+    )
+
+    prox = FeatureSpaceProximity(df, id_column="id", features=["size", "color"])
+    encoded = prox._encode_feature_frame(pd.DataFrame({"size": [1.0], "color": ["green"]}))
+
+    assert encoded.columns.tolist() == prox._encoded_features
+    assert "color_green" not in encoded.columns
+    assert encoded.filter(like="color_").sum(axis=1).iloc[0] == 0.0


### PR DESCRIPTION
## Summary
- allow FeatureSpaceProximity to keep categorical/object/string/bool features by one-hot encoding them for nearest-neighbor fitting and query transforms
- preserve the public feature list while using the encoded matrix internally for scaling, neighbors, and 2D projection
- add focused tests for categorical neighbor selection and unseen query categories aligning to the training columns

Fixes #525

## Validation
- py -m py_compile src\workbench\algorithms\dataframe\feature_space_proximity.py tests\specific\feature_space_proximity_categorical_test.py
- $env:PYTHONPATH='src'; py -m pytest tests\specific\feature_space_proximity_categorical_test.py -q --no-cov (2 skipped locally because pandas/scikit-learn are not installed in this checkout)
- py -m black --check src\workbench\algorithms\dataframe\feature_space_proximity.py tests\specific\feature_space_proximity_categorical_test.py
- py -m flake8 src\workbench\algorithms\dataframe\feature_space_proximity.py tests\specific\feature_space_proximity_categorical_test.py
- py -m isort --profile black --line-length 120 --check-only src\workbench\algorithms\dataframe\feature_space_proximity.py tests\specific\feature_space_proximity_categorical_test.py
- git diff --cached --check