### PR TITLE
Preserve invalid SMILES rows in fingerprint output

### DIFF
--- a/src/workbench/utils/chem_utils/fingerprints.py
+++ b/src/workbench/utils/chem_utils/fingerprints.py
@@ -38,25 +38,16 @@ def compute_morgan_fingerprints(df: pd.DataFrame, radius: int = 2, n_bits: int =
 
     Returns:
         pd.DataFrame: Input DataFrame with 'fingerprint' column added.
-                      Values are comma-separated uint8 counts.
+                      Values are comma-separated uint8 counts. Rows whose
+                      SMILES cannot be fingerprinted are preserved with
+                      pandas missing values in the fingerprint column.
 
     Note:
         Count fingerprints outperform binary for ADMET prediction.
         See: https://pubs.acs.org/doi/10.1021/acs.est.3c02198
 
-    Future Me:
-        This silently drops rows whose SMILES RDKit can't parse, so the output
-        has fewer rows than the input. Callers downstream (FingerprintProximity,
-        residual_features, UQModelV1) currently work around this by pre-validating
-        SMILES at their own layer — which means MolFromSmiles runs twice per
-        SMILES on the inference path. The cleaner fix is one of:
-          (a) preserve the input's DataFrame index when dropping rows so
-              callers can derive a survivor mask via `df_out.index`, or
-          (b) keep all rows and put NaN in the fingerprint column for failures
-              (more pandas/sklearn-idiomatic).
-        Either would let `FingerprintProximity.neighbors_from_query_df` drop
-        its redundant pre-validate. Deferred — see the workaround in
-        fingerprint_proximity.py.
+        Invalid or unsupported SMILES keep their input row. This avoids endpoint
+        response shape mismatches when a batch contains one bad compound.
     """
     delete_mol_column = False
 
@@ -76,37 +67,52 @@ def compute_morgan_fingerprints(df: pd.DataFrame, radius: int = 2, n_bits: int =
         delete_mol_column = True
 
         def _safe_mol_from_smiles(smi):
-            if smi is None or pd.isna(smi) or not isinstance(smi, str) or not smi:
+            if smi is None or pd.isna(smi) or not isinstance(smi, str) or not smi.strip():
                 return None
-            return Chem.MolFromSmiles(smi)
+            try:
+                return Chem.MolFromSmiles(smi.strip())
+            except Exception as e:
+                log.warning(f"Failed to parse SMILES {smi!r}: {e}")
+                return None
 
         df["molecule"] = df[smiles_column].apply(_safe_mol_from_smiles)
-        # Make sure our molecules are not None
         failed_smiles = df[df["molecule"].isnull()][smiles_column].tolist()
         if failed_smiles:
             log.warning(f"Failed to convert {len(failed_smiles)} SMILES to molecules ({failed_smiles})")
-        df = df.dropna(subset=["molecule"]).copy()
 
     # If we have fragments in our compounds, get the largest fragment before computing fingerprints
-    largest_frags = df["molecule"].apply(
-        lambda mol: rdMolStandardize.LargestFragmentChooser().choose(mol) if mol else None
-    )
+    fragment_chooser = rdMolStandardize.LargestFragmentChooser()
+
+    def _largest_fragment(mol):
+        if mol is None:
+            return None
+        try:
+            return fragment_chooser.choose(mol)
+        except Exception as e:
+            log.warning(f"Failed to choose largest fragment: {e}")
+            return None
+
+    largest_frags = df["molecule"].apply(_largest_fragment)
 
     def mol_to_count_string(mol):
         """Convert molecule to comma-separated count fingerprint string."""
         if mol is None:
             return pd.NA
 
-        # Get hashed Morgan fingerprint with counts
-        fp = AllChem.GetHashedMorganFingerprint(mol, radius, nBits=n_bits)
+        try:
+            # Get hashed Morgan fingerprint with counts
+            fp = AllChem.GetHashedMorganFingerprint(mol, radius, nBits=n_bits)
 
-        # Initialize array and populate with counts (clamped to uint8 range)
-        counts = np.zeros(n_bits, dtype=np.uint8)
-        for idx, count in fp.GetNonzeroElements().items():
-            counts[idx] = min(count, 255)
+            # Initialize array and populate with counts (clamped to uint8 range)
+            counts = np.zeros(n_bits, dtype=np.uint8)
+            for idx, count in fp.GetNonzeroElements().items():
+                counts[idx] = min(count, 255)
 
-        # Return as comma-separated string
-        return ",".join(map(str, counts))
+            # Return as comma-separated string
+            return ",".join(map(str, counts))
+        except Exception as e:
+            log.warning(f"Failed to compute Morgan fingerprint: {e}")
+            return pd.NA
 
     # Compute Morgan count fingerprints
     fingerprints = largest_frags.apply(mol_to_count_string)

--- a/tests/specific/fingerprints_invalid_smiles_test.py
+++ b/tests/specific/fingerprints_invalid_smiles_test.py
@@ -1,0 +1,56 @@
+"""Tests for resilient Morgan fingerprint generation."""
+
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("pandas") is None or importlib.util.find_spec("rdkit") is None,
+    reason="pandas and rdkit are required for fingerprint tests",
+)
+
+
+def _test_deps():
+    import pandas as pd
+
+    from workbench.utils.chem_utils.fingerprints import compute_morgan_fingerprints
+
+    return pd, compute_morgan_fingerprints
+
+
+def test_invalid_smiles_rows_are_preserved():
+    pd, compute_morgan_fingerprints = _test_deps()
+    df = pd.DataFrame(
+        {
+            "id": ["bad", "good", "blank"],
+            "smiles": ["INVALID", "CCO", ""],
+        }
+    )
+
+    out = compute_morgan_fingerprints(df)
+
+    assert out["id"].tolist() == ["bad", "good", "blank"]
+    assert pd.isna(out.loc[out["id"] == "bad", "fingerprint"]).iloc[0]
+    assert isinstance(out.loc[out["id"] == "good", "fingerprint"].iloc[0], str)
+    assert pd.isna(out.loc[out["id"] == "blank", "fingerprint"]).iloc[0]
+    assert "molecule" not in out.columns
+
+
+def test_existing_invalid_molecule_rows_are_preserved():
+    pd, compute_morgan_fingerprints = _test_deps()
+    from rdkit import Chem
+
+    df = pd.DataFrame(
+        {
+            "id": ["good", "bad"],
+            "SMILES": ["CCO", "INVALID"],
+            "molecule": [Chem.MolFromSmiles("CCO"), None],
+        }
+    )
+
+    out = compute_morgan_fingerprints(df)
+
+    assert out["id"].tolist() == ["good", "bad"]
+    assert isinstance(out.loc[out["id"] == "good", "fingerprint"].iloc[0], str)
+    assert pd.isna(out.loc[out["id"] == "bad", "fingerprint"]).iloc[0]
+    assert "molecule" in out.columns


### PR DESCRIPTION
## Summary
- preserve rows whose SMILES cannot be parsed or fingerprinted instead of dropping them from endpoint output
- return missing fingerprint values for invalid/unsupported molecules so batch response shape stays aligned with input rows
- catch RDKit parsing, fragment selection, and fingerprint-generation failures without crashing the whole batch
- add focused tests for invalid SMILES and pre-existing invalid molecule rows

Fixes #534

## Validation
- py -m py_compile src\workbench\utils\chem_utils\fingerprints.py tests\specific\fingerprints_invalid_smiles_test.py
- $env:PYTHONPATH='src'; py -m pytest tests\specific\fingerprints_invalid_smiles_test.py -q --no-cov (2 skipped locally because pandas/rdkit are not installed in this checkout)
- py -m black --check src\workbench\utils\chem_utils\fingerprints.py tests\specific\fingerprints_invalid_smiles_test.py
- py -m flake8 src\workbench\utils\chem_utils\fingerprints.py tests\specific\fingerprints_invalid_smiles_test.py
- py -m isort --profile black --line-length 120 --check-only src\workbench\utils\chem_utils\fingerprints.py tests\specific\fingerprints_invalid_smiles_test.py
- git diff --cached --check