### PR TITLE
Show table filters by default

### DIFF
--- a/src/workbench/web_interface/components/plugins/ag_table.py
+++ b/src/workbench/web_interface/components/plugins/ag_table.py
@@ -1,12 +1,12 @@
 """An Example Table plugin component using AG Grid"""
 
 import logging
+
 import pandas as pd
 from dash_ag_grid import AgGrid
 
-# Workbench Imports
-from workbench.web_interface.components.plugin_interface import PluginInterface, PluginPage, PluginInputType
 from workbench.utils.symbols import tag_symbols
+from workbench.web_interface.components.plugin_interface import PluginInputType, PluginInterface, PluginPage
 
 # Get the Workbench logger
 log = logging.getLogger("workbench")
@@ -20,6 +20,7 @@ class AGTable(PluginInterface):
     plugin_input_type = PluginInputType.DATAFRAME
     max_height = 500
     header_height = 36
+    floating_filter_height = 36
     row_height = 25
     # Thin columns: small by default (auto-size cap) but user can drag wider
     thin_columns = {"Health": 100, "Owner": 100}
@@ -44,7 +45,8 @@ class AGTable(PluginInterface):
             "rowSelection": row_selection,
             "suppressCellFocus": True,
             "rowHeight": self.row_height,
-            "defaultColDef": {"sortable": True, "filter": True, "resizable": True},
+            "defaultColDef": {"sortable": True, "filter": True, "floatingFilter": True, "resizable": True},
+            "floatingFiltersHeight": self.floating_filter_height,
             "autoSizeStrategy": {
                 "type": "fitCellContents",
                 "defaultMaxWidth": 400,
@@ -96,7 +98,8 @@ class AGTable(PluginInterface):
 
         # Dynamically adjust height based on row count
         row_count = len(table_df)
-        computed_height = min(self.header_height + self.row_height * row_count, self.max_height) + 2
+        table_header_height = self.header_height + self.floating_filter_height
+        computed_height = min(table_header_height + self.row_height * row_count, self.max_height) + 2
         style = {"height": f"{computed_height}px", "overflow": "auto"}
 
         # Return the column definitions, table data, and style (must match the plugin properties)

--- a/tests/specific/ag_table_filter_test.py
+++ b/tests/specific/ag_table_filter_test.py
@@ -1,0 +1,81 @@
+"""Tests for the AG Table plugin configuration."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+class FakeAgGrid:
+    """Minimal stand-in for dash_ag_grid.AgGrid."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class FakeDataFrame:
+    """Small DataFrame stand-in for AGTable.update_properties()."""
+
+    columns = ["Name", "Score"]
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __len__(self):
+        return len(self._rows)
+
+    def to_dict(self, orient):
+        assert orient == "records"
+        return self._rows
+
+
+def load_ag_table_module(monkeypatch):
+    """Load ag_table.py with lightweight stubs for optional UI dependencies."""
+    pandas_module = ModuleType("pandas")
+    pandas_module.DataFrame = FakeDataFrame
+    monkeypatch.setitem(sys.modules, "pandas", pandas_module)
+
+    dash_ag_grid_module = ModuleType("dash_ag_grid")
+    dash_ag_grid_module.AgGrid = FakeAgGrid
+    monkeypatch.setitem(sys.modules, "dash_ag_grid", dash_ag_grid_module)
+
+    plugin_interface_module = ModuleType("workbench.web_interface.components.plugin_interface")
+    plugin_interface_module.PluginInterface = object
+    plugin_interface_module.PluginPage = SimpleNamespace(NONE="none")
+    plugin_interface_module.PluginInputType = SimpleNamespace(DATAFRAME="dataframe")
+    monkeypatch.setitem(sys.modules, "workbench.web_interface.components.plugin_interface", plugin_interface_module)
+
+    symbols_module = ModuleType("workbench.utils.symbols")
+    symbols_module.tag_symbols = lambda value: value
+    monkeypatch.setitem(sys.modules, "workbench.utils.symbols", symbols_module)
+
+    module_path = (
+        Path(__file__).parents[2] / "src" / "workbench" / "web_interface" / "components" / "plugins" / "ag_table.py"
+    )
+    spec = importlib.util.spec_from_file_location("ag_table_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ag_table_shows_floating_filters_by_default(monkeypatch):
+    module = load_ag_table_module(monkeypatch)
+    table = module.AGTable()
+
+    component = table.create_component("table")
+
+    options = component.kwargs["dashGridOptions"]
+    assert options["defaultColDef"]["filter"] is True
+    assert options["defaultColDef"]["floatingFilter"] is True
+    assert options["floatingFiltersHeight"] == table.floating_filter_height
+
+
+def test_ag_table_height_includes_floating_filter_row(monkeypatch):
+    module = load_ag_table_module(monkeypatch)
+    table = module.AGTable()
+    table.create_component("table", max_height=500)
+
+    _, _, style = table.update_properties(FakeDataFrame([{"Name": "a", "Score": 1}, {"Name": "b", "Score": 2}]))
+
+    expected_height = table.header_height + table.floating_filter_height + table.row_height * 2 + 2
+    assert style["height"] == f"{expected_height}px"


### PR DESCRIPTION
## Summary
- enable AG Grid floating filters on the shared Workbench table component so filter inputs are visible by default
- include the floating-filter row in table height calculation so rows are not clipped
- add dependency-light coverage for the grid options and height calculation

Fixes #439.

## Validation
- py -m py_compile src\\workbench\\web_interface\\components\\plugins\\ag_table.py tests\\specific\\ag_table_filter_test.py
- py -m pytest tests\\specific\\ag_table_filter_test.py -q --no-cov
- py -m black --target-version py313 --check --line-length=120 src\\workbench\\web_interface\\components\\plugins\\ag_table.py tests\\specific\\ag_table_filter_test.py
- py -m flake8 src\\workbench\\web_interface\\components\\plugins\\ag_table.py tests\\specific\\ag_table_filter_test.py
- py -m isort --profile black --line-length 120 --check-only src\\workbench\\web_interface\\components\\plugins\\ag_table.py tests\\specific\\ag_table_filter_test.py
- git diff --check