### PR TITLE
Open AWS SSO login on token failure

### DIFF
--- a/src/workbench/core/cloud_platform/aws/aws_account_clamp.py
+++ b/src/workbench/core/cloud_platform/aws/aws_account_clamp.py
@@ -1,13 +1,14 @@
 """AWSAccountClamp provides logic/functionality over a set of AWS IAM Services"""
 
+import logging
+
 import boto3
+from botocore.client import BaseClient
 from botocore.exceptions import (
     ClientError,
-    UnauthorizedSSOTokenError,
     TokenRetrievalError,
+    UnauthorizedSSOTokenError,
 )
-from botocore.client import BaseClient
-import logging
 from sagemaker.core.helper.session_helper import Session as SageSession
 
 # Workbench Imports
@@ -49,8 +50,16 @@ class AWSAccountClamp:
             self.account_id = boto3.client("sts").get_caller_identity()["Account"]
             self.region = boto3.session.Session().region_name
         except (ClientError, UnauthorizedSSOTokenError, TokenRetrievalError):
-            self.log.critical("AWS Identity Check Failure: Check AWS_PROFILE and/or Renew SSO Token...")
-            raise FatalConfigError()
+            if self.aws_session.renew_sso_login():
+                try:
+                    self.account_id = boto3.client("sts").get_caller_identity()["Account"]
+                    self.region = boto3.session.Session().region_name
+                except (ClientError, UnauthorizedSSOTokenError, TokenRetrievalError):
+                    self.log.critical("AWS Identity Check Failure: Check AWS_PROFILE and/or Renew SSO Token...")
+                    raise FatalConfigError()
+            else:
+                self.log.critical("AWS Identity Check Failure: Check AWS_PROFILE and/or Renew SSO Token...")
+                raise FatalConfigError()
 
         # Check our Assume Role
         self.log.info("Checking Workbench Assumed Role...")
@@ -77,6 +86,13 @@ class AWSAccountClamp:
             sts.get_caller_identity()
             return True
         except (ClientError, UnauthorizedSSOTokenError):
+            if self.aws_session.renew_sso_login():
+                try:
+                    sts = boto3.client("sts")
+                    sts.get_caller_identity()
+                    return True
+                except (ClientError, UnauthorizedSSOTokenError):
+                    pass
             msg = "AWS Identity Check Failure: Check AWS_PROFILE and/or Renew SSO Token..."
             self.log.critical(msg)
             raise RuntimeError(msg)

--- a/src/workbench/core/cloud_platform/aws/aws_session.py
+++ b/src/workbench/core/cloud_platform/aws/aws_session.py
@@ -1,18 +1,19 @@
+import logging
 import os
+import re
+import shutil
+import subprocess
 import sys
 
 import boto3
-import re
-from botocore.exceptions import ClientError, UnauthorizedSSOTokenError, TokenRetrievalError, SSOTokenLoadError
 from botocore.credentials import RefreshableCredentials
+from botocore.exceptions import ClientError, SSOTokenLoadError, TokenRetrievalError, UnauthorizedSSOTokenError
 from botocore.session import get_session
-import logging
 
 # Workbench Imports
 from workbench.utils.config_manager import ConfigManager
 from workbench.utils.execution_environment import running_as_service
-
-from workbench.utils.ipython_utils import is_running_in_ipython, display_error_and_raise
+from workbench.utils.ipython_utils import display_error_and_raise, is_running_in_ipython
 
 
 class AWSSession:
@@ -35,23 +36,59 @@ class AWSSession:
             self.workbench_role_name = self.cm.get_config("WORKBENCH_ROLE")
 
             # Grab the AWS Profile from the Config Manager
-            profile = self.cm.get_config("AWS_PROFILE")
-            if profile is not None:
-                os.environ["AWS_PROFILE"] = profile
+            self.profile = self.cm.get_config("AWS_PROFILE") or os.environ.get("AWS_PROFILE")
+            if self.profile is not None:
+                os.environ["AWS_PROFILE"] = self.profile
 
             # Grab our AWS Account Info
             try:
-                self.account_id = boto3.client("sts").get_caller_identity()["Account"]
-                self.region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION"))
-                self.region = boto3.Session().region_name if self.region is None else self.region
+                self._set_account_info()
             except (ClientError, UnauthorizedSSOTokenError, TokenRetrievalError, SSOTokenLoadError):
                 msg = "AWS SSO Token Failure: Check AWS_PROFILE and/or Renew SSO Token..."
                 self.log.critical(msg)
-                if is_running_in_ipython():
-                    display_error_and_raise(msg)
+                if self.renew_sso_login():
+                    try:
+                        self._set_account_info()
+                    except (ClientError, UnauthorizedSSOTokenError, TokenRetrievalError, SSOTokenLoadError):
+                        self._sso_failure_exit(msg)
                 else:
-                    sys.exit(1)
+                    self._sso_failure_exit(msg)
             self.initialized = True  # Mark as initialized to prevent reinitialization
+
+    def _set_account_info(self):
+        """Set AWS account and region information from the active caller identity."""
+        self.account_id = boto3.client("sts").get_caller_identity()["Account"]
+        self.region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION"))
+        self.region = boto3.Session().region_name if self.region is None else self.region
+
+    def renew_sso_login(self) -> bool:
+        """Try to renew the configured AWS SSO profile through the AWS CLI."""
+        if running_as_service() or not self.profile:
+            return False
+
+        if shutil.which("aws") is None:
+            self.log.warning("AWS CLI not found; cannot open AWS SSO login automatically.")
+            return False
+
+        self.log.important(f"Opening AWS SSO login for profile '{self.profile}'...")
+        try:
+            result = subprocess.run(["aws", "sso", "login", "--profile", self.profile], check=False)
+        except OSError as err:
+            self.log.warning(f"Failed to launch AWS SSO login: {err}")
+            return False
+
+        if result.returncode != 0:
+            self.log.warning(f"AWS SSO login failed for profile '{self.profile}' with exit code {result.returncode}.")
+            return False
+        return True
+
+    @staticmethod
+    def _sso_failure_exit(msg: str):
+        """Exit or raise after SSO renewal has failed."""
+        if is_running_in_ipython():
+            display_error_and_raise(msg)
+        else:
+            sys.exit(1)
 
     @property
     def boto3_session(self):

--- a/tests/specific/aws_sso_login_test.py
+++ b/tests/specific/aws_sso_login_test.py
@@ -1,0 +1,99 @@
+"""Tests for AWS SSO login renewal helpers."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+class FakeLog:
+    def __init__(self):
+        self.messages = []
+
+    def important(self, message):
+        self.messages.append(("important", message))
+
+    def warning(self, message):
+        self.messages.append(("warning", message))
+
+
+def load_aws_session_module(monkeypatch):
+    """Load aws_session.py with stubs for optional AWS dependencies."""
+    boto3_module = ModuleType("boto3")
+    boto3_module.client = lambda *_args, **_kwargs: None
+    boto3_module.Session = lambda *_args, **_kwargs: SimpleNamespace(region_name="us-east-1")
+    monkeypatch.setitem(sys.modules, "boto3", boto3_module)
+
+    botocore_module = ModuleType("botocore")
+    exceptions_module = ModuleType("botocore.exceptions")
+    for name in ["ClientError", "UnauthorizedSSOTokenError", "TokenRetrievalError", "SSOTokenLoadError"]:
+        setattr(exceptions_module, name, type(name, (Exception,), {}))
+    monkeypatch.setitem(sys.modules, "botocore", botocore_module)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", exceptions_module)
+
+    credentials_module = ModuleType("botocore.credentials")
+    credentials_module.RefreshableCredentials = SimpleNamespace(create_from_metadata=lambda **_kwargs: object())
+    monkeypatch.setitem(sys.modules, "botocore.credentials", credentials_module)
+
+    session_module = ModuleType("botocore.session")
+    session_module.get_session = lambda: SimpleNamespace(_credentials=None)
+    monkeypatch.setitem(sys.modules, "botocore.session", session_module)
+
+    config_module = ModuleType("workbench.utils.config_manager")
+    config_module.ConfigManager = object
+    monkeypatch.setitem(sys.modules, "workbench.utils.config_manager", config_module)
+
+    env_module = ModuleType("workbench.utils.execution_environment")
+    env_module.running_as_service = lambda: False
+    monkeypatch.setitem(sys.modules, "workbench.utils.execution_environment", env_module)
+
+    ipython_module = ModuleType("workbench.utils.ipython_utils")
+    ipython_module.is_running_in_ipython = lambda: False
+    ipython_module.display_error_and_raise = lambda message: (_ for _ in ()).throw(RuntimeError(message))
+    monkeypatch.setitem(sys.modules, "workbench.utils.ipython_utils", ipython_module)
+
+    module_path = Path(__file__).parents[2] / "src" / "workbench" / "core" / "cloud_platform" / "aws" / "aws_session.py"
+    spec = importlib.util.spec_from_file_location("aws_session_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_session(module, profile="dev"):
+    session = module.AWSSession.__new__(module.AWSSession)
+    session.profile = profile
+    session.log = FakeLog()
+    return session
+
+
+def test_renew_sso_login_runs_aws_cli(monkeypatch):
+    module = load_aws_session_module(monkeypatch)
+    session = make_session(module)
+    calls = []
+
+    monkeypatch.setattr(module.shutil, "which", lambda command: "aws.exe" if command == "aws" else None)
+    monkeypatch.setattr(
+        module.subprocess, "run", lambda command, check: calls.append((command, check)) or SimpleNamespace(returncode=0)
+    )
+
+    assert session.renew_sso_login() is True
+    assert calls == [(["aws", "sso", "login", "--profile", "dev"], False)]
+
+
+def test_renew_sso_login_skips_without_profile(monkeypatch):
+    module = load_aws_session_module(monkeypatch)
+    session = make_session(module, profile=None)
+
+    monkeypatch.setattr(module.shutil, "which", lambda _command: "aws.exe")
+
+    assert session.renew_sso_login() is False
+
+
+def test_renew_sso_login_skips_without_aws_cli(monkeypatch):
+    module = load_aws_session_module(monkeypatch)
+    session = make_session(module)
+
+    monkeypatch.setattr(module.shutil, "which", lambda _command: None)
+
+    assert session.renew_sso_login() is False
+    assert ("warning", "AWS CLI not found; cannot open AWS SSO login automatically.") in session.log.messages


### PR DESCRIPTION
## Summary
- retry AWS caller identity checks after opening ws sso login --profile <profile> when an SSO token failure is detected
- skip automatic login renewal in service mode, without an AWS profile, or when the AWS CLI is unavailable
- reuse the renewal path from AWSAccountClamp identity checks and add focused stubbed coverage

Fixes #470.

## Validation
- py -m py_compile src\\workbench\\core\\cloud_platform\\aws\\aws_session.py src\\workbench\\core\\cloud_platform\\aws\\aws_account_clamp.py tests\\specific\\aws_sso_login_test.py
- py -m pytest tests\\specific\\aws_sso_login_test.py -q --no-cov
- py -m black --target-version py313 --check --line-length=120 src\\workbench\\core\\cloud_platform\\aws\\aws_session.py src\\workbench\\core\\cloud_platform\\aws\\aws_account_clamp.py tests\\specific\\aws_sso_login_test.py
- py -m flake8 src\\workbench\\core\\cloud_platform\\aws\\aws_session.py src\\workbench\\core\\cloud_platform\\aws\\aws_account_clamp.py tests\\specific\\aws_sso_login_test.py
- py -m isort --profile black --line-length 120 --check-only src\\workbench\\core\\cloud_platform\\aws\\aws_session.py src\\workbench\\core\\cloud_platform\\aws\\aws_account_clamp.py tests\\specific\\aws_sso_login_test.py
- git diff --check