### PR TITLE
Show waiting placeholders during row selection

### DIFF
--- a/applications/aws_dashboard/pages/data_sources/callbacks.py
+++ b/applications/aws_dashboard/pages/data_sources/callbacks.py
@@ -1,19 +1,27 @@
 """FeatureSets Callbacks: Callback within the DataSources Web User Interface"""
 
-import dash
-from dash import callback, Input, Output, State
-from dash.exceptions import PreventUpdate
-import plotly.graph_objects as go
-import pandas as pd
 import logging
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
+
+import dash
+import pandas as pd
+import plotly.graph_objects as go
+from dash import Input, Output, State, callback
+from dash.exceptions import PreventUpdate
+
+from workbench.cached.cached_data_source import CachedDataSource
+from workbench.web_interface.components import correlation_matrix, violin_plots
+from workbench.web_interface.components.loading_state import (
+    WAITING_HEADER,
+    WAITING_MARKDOWN,
+    waiting_figure,
+    waiting_table,
+)
+from workbench.web_interface.components.plugins.ag_table import AGTable
+from workbench.web_interface.components.plugins.data_details import DataDetails
 
 # Workbench Imports
 from workbench.web_interface.page_views.data_sources_page_view import DataSourcesPageView
-from workbench.web_interface.components import violin_plots, correlation_matrix
-from workbench.web_interface.components.plugins.ag_table import AGTable
-from workbench.web_interface.components.plugins.data_details import DataDetails
-from workbench.cached.cached_data_source import CachedDataSource
 
 # Set up logging
 log = logging.getLogger("workbench")
@@ -66,6 +74,37 @@ def data_sources_refresh(page_view: DataSourcesPageView, ds_table: AGTable):
         data_sources["name"] = data_sources["Name"]
         data_sources["id"] = range(len(data_sources))
         return ds_table.update_properties(data_sources)
+
+
+def show_waiting_for_data_on_row_selection():
+    @callback(
+        [
+            Output("data_details-header", "children", allow_duplicate=True),
+            Output("data_details-details", "children", allow_duplicate=True),
+            Output("sample_rows_header", "children", allow_duplicate=True),
+            Output("data_source_sample_rows", "columnDefs", allow_duplicate=True),
+            Output("data_source_sample_rows", "rowData", allow_duplicate=True),
+            Output("data_source_violin_plot", "figure", allow_duplicate=True),
+            Output("data_source_correlation_matrix", "figure", allow_duplicate=True),
+        ],
+        Input("data_sources_table", "selectedRows"),
+        prevent_initial_call=True,
+    )
+    def _show_waiting_for_data(selected_rows):
+        if not selected_rows or selected_rows[0] is None:
+            raise PreventUpdate
+
+        column_defs, row_data = waiting_table()
+        figure = waiting_figure()
+        return [
+            WAITING_HEADER,
+            WAITING_MARKDOWN,
+            "Sample/Outlier Rows: Waiting for data...",
+            column_defs,
+            row_data,
+            figure,
+            figure,
+        ]
 
 
 # Updates the data source details and the correlation matrix when a new DataSource is selected

--- a/applications/aws_dashboard/pages/data_sources/page.py
+++ b/applications/aws_dashboard/pages/data_sources/page.py
@@ -3,14 +3,15 @@
 from dash import register_page
 
 # Workbench Imports
-from workbench.web_interface.components import violin_plots, correlation_matrix
+from workbench.web_interface.components import correlation_matrix, violin_plots
 from workbench.web_interface.components.plugins.ag_table import AGTable
 from workbench.web_interface.components.plugins.data_details import DataDetails
 from workbench.web_interface.page_views.data_sources_page_view import DataSourcesPageView
 
+from . import callbacks
+
 # Local Imports
 from .layout import data_sources_layout
-from . import callbacks
 
 register_page(
     __name__,
@@ -59,6 +60,7 @@ callbacks.on_page_load()
 callbacks.data_sources_refresh(data_source_view, data_sources_table)
 
 # Callbacks for when a data source is selected
+callbacks.show_waiting_for_data_on_row_selection()
 callbacks.update_data_source_details(data_details)
 callbacks.update_data_source_sample_rows(samples_table)
 

--- a/applications/aws_dashboard/pages/feature_sets/callbacks.py
+++ b/applications/aws_dashboard/pages/feature_sets/callbacks.py
@@ -1,19 +1,27 @@
 """Callbacks for the FeatureSets Subpage Web User Interface"""
 
-import dash
-from dash import callback, Input, Output, State
-from dash.exceptions import PreventUpdate
-import plotly.graph_objects as go
-import pandas as pd
 import logging
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
+
+import dash
+import pandas as pd
+import plotly.graph_objects as go
+from dash import Input, Output, State, callback
+from dash.exceptions import PreventUpdate
+
+from workbench.cached.cached_feature_set import CachedFeatureSet
+from workbench.web_interface.components import correlation_matrix, violin_plots
+from workbench.web_interface.components.loading_state import (
+    WAITING_HEADER,
+    WAITING_MARKDOWN,
+    waiting_figure,
+    waiting_table,
+)
+from workbench.web_interface.components.plugins.ag_table import AGTable
+from workbench.web_interface.components.plugins.data_details import DataDetails
 
 # Workbench Imports
 from workbench.web_interface.page_views.feature_sets_page_view import FeatureSetsPageView
-from workbench.web_interface.components import violin_plots, correlation_matrix
-from workbench.web_interface.components.plugins.ag_table import AGTable
-from workbench.web_interface.components.plugins.data_details import DataDetails
-from workbench.cached.cached_feature_set import CachedFeatureSet
 
 # Set up logging
 log = logging.getLogger("workbench")
@@ -66,6 +74,37 @@ def feature_sets_refresh(page_view: FeatureSetsPageView, fs_table: AGTable):
         feature_sets["name"] = feature_sets["Feature Group"]
         feature_sets["id"] = range(len(feature_sets))
         return fs_table.update_properties(feature_sets)
+
+
+def show_waiting_for_data_on_row_selection():
+    @callback(
+        [
+            Output("feature_set_details-header", "children", allow_duplicate=True),
+            Output("feature_set_details-details", "children", allow_duplicate=True),
+            Output("feature_sample_rows_header", "children", allow_duplicate=True),
+            Output("feature_set_sample_rows", "columnDefs", allow_duplicate=True),
+            Output("feature_set_sample_rows", "rowData", allow_duplicate=True),
+            Output("feature_set_violin_plot", "figure", allow_duplicate=True),
+            Output("feature_set_correlation_matrix", "figure", allow_duplicate=True),
+        ],
+        Input("feature_sets_table", "selectedRows"),
+        prevent_initial_call=True,
+    )
+    def _show_waiting_for_data(selected_rows):
+        if not selected_rows or selected_rows[0] is None:
+            raise PreventUpdate
+
+        column_defs, row_data = waiting_table()
+        figure = waiting_figure()
+        return [
+            WAITING_HEADER,
+            WAITING_MARKDOWN,
+            "Sample/Outlier Rows: Waiting for data...",
+            column_defs,
+            row_data,
+            figure,
+            figure,
+        ]
 
 
 # Updates the feature set details and correlation matrix when a new FeatureSet is selected

--- a/applications/aws_dashboard/pages/feature_sets/page.py
+++ b/applications/aws_dashboard/pages/feature_sets/page.py
@@ -3,14 +3,15 @@
 from dash import register_page
 
 # Workbench Imports
-from workbench.web_interface.components import violin_plots, correlation_matrix
+from workbench.web_interface.components import correlation_matrix, violin_plots
 from workbench.web_interface.components.plugins.ag_table import AGTable
 from workbench.web_interface.components.plugins.data_details import DataDetails
 from workbench.web_interface.page_views.feature_sets_page_view import FeatureSetsPageView
 
+from . import callbacks
+
 # Local Imports
 from .layout import feature_sets_layout
-from . import callbacks
 
 register_page(__name__, path="/feature_sets", name="Workbench - Feature Sets")
 
@@ -55,6 +56,7 @@ callbacks.on_page_load()
 callbacks.feature_sets_refresh(feature_set_view, feature_sets_table)
 
 # Callbacks for when a feature set is selected
+callbacks.show_waiting_for_data_on_row_selection()
 callbacks.update_feature_set_details(feature_details)
 callbacks.update_feature_set_sample_rows(samples_table)
 

--- a/src/workbench/web_interface/components/loading_state.py
+++ b/src/workbench/web_interface/components/loading_state.py
@@ -1,0 +1,36 @@
+"""Shared loading placeholders for dashboard callbacks."""
+
+import plotly.graph_objects as go
+
+WAITING_MARKDOWN = "*Waiting for data...*"
+WAITING_HEADER = "Loading..."
+WAITING_TABLE_TEXT = "Waiting for data..."
+WAITING_FIGURE_TEXT = "Waiting for Data..."
+
+
+def waiting_figure(text_message: str = WAITING_FIGURE_TEXT) -> go.Figure:
+    """Return the same style of text-only figure used by unloaded graph components."""
+    figure = go.Figure()
+    figure.add_annotation(
+        x=0.5,
+        y=0.5,
+        xref="paper",
+        yref="paper",
+        text=text_message,
+        bgcolor="rgba(0,0,0,0)",
+        showarrow=False,
+        font=dict(size=24, color="#9999cc"),
+    )
+    figure.update_layout(
+        xaxis=dict(showticklabels=False, zeroline=False, showgrid=False),
+        yaxis=dict(showticklabels=False, zeroline=False, showgrid=False),
+        margin=dict(l=0, r=0, b=0, t=0),
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+    )
+    return figure
+
+
+def waiting_table() -> tuple[list[dict], list[dict]]:
+    """Return a one-row table placeholder for dependent row-selection tables."""
+    return [{"headerName": "Status", "field": "status"}], [{"status": WAITING_TABLE_TEXT}]

--- a/tests/specific/loading_state_test.py
+++ b/tests/specific/loading_state_test.py
@@ -1,0 +1,47 @@
+"""Tests for dashboard loading placeholders."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parents[2] / "src" / "workbench" / "web_interface" / "components" / "loading_state.py"
+
+
+class _FakeFigure:
+    def __init__(self):
+        self.layout = types.SimpleNamespace(annotations=[])
+
+    def add_annotation(self, **kwargs):
+        self.layout.annotations.append(types.SimpleNamespace(**kwargs))
+
+    def update_layout(self, **kwargs):
+        for key, value in kwargs.items():
+            if isinstance(value, dict):
+                value = types.SimpleNamespace(**value)
+            setattr(self.layout, key, value)
+
+
+fake_graph_objects = types.SimpleNamespace(Figure=_FakeFigure)
+sys.modules.setdefault("plotly", types.SimpleNamespace(graph_objects=fake_graph_objects))
+sys.modules.setdefault("plotly.graph_objects", fake_graph_objects)
+
+SPEC = importlib.util.spec_from_file_location("loading_state", MODULE_PATH)
+loading_state = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(loading_state)
+
+
+def test_waiting_table_has_status_row():
+    column_defs, row_data = loading_state.waiting_table()
+
+    assert column_defs == [{"headerName": "Status", "field": "status"}]
+    assert row_data == [{"status": "Waiting for data..."}]
+
+
+def test_waiting_figure_has_centered_status_text():
+    figure = loading_state.waiting_figure()
+
+    assert figure.layout.annotations[0].text == "Waiting for Data..."
+    assert figure.layout.annotations[0].showarrow is False
+    assert figure.layout.xaxis.showticklabels is False
+    assert loading_state.WAITING_MARKDOWN == "*Waiting for data...*"


### PR DESCRIPTION
## Summary
- add shared dashboard loading placeholders for text figures and dependent tables
- reset DataSources detail/sample/plot/correlation outputs to waiting placeholders immediately when a new row is selected
- apply the same row-selection waiting state to FeatureSets

Fixes #369.

## Validation
- py -m pytest tests\\specific\\loading_state_test.py -q --no-cov
- py -m py_compile src\\workbench\\web_interface\\components\\loading_state.py applications\\aws_dashboard\\pages\\data_sources\\callbacks.py applications\\aws_dashboard\\pages\\data_sources\\page.py applications\\aws_dashboard\\pages\\feature_sets\\callbacks.py applications\\aws_dashboard\\pages\\feature_sets\\page.py tests\\specific\\loading_state_test.py
- py -m black --target-version py313 --check --line-length=120 src\\workbench\\web_interface\\components\\loading_state.py applications\\aws_dashboard\\pages\\data_sources\\callbacks.py applications\\aws_dashboard\\pages\\data_sources\\page.py applications\\aws_dashboard\\pages\\feature_sets\\callbacks.py applications\\aws_dashboard\\pages\\feature_sets\\page.py tests\\specific\\loading_state_test.py
- py -m flake8 src\\workbench\\web_interface\\components\\loading_state.py applications\\aws_dashboard\\pages\\data_sources\\callbacks.py applications\\aws_dashboard\\pages\\data_sources\\page.py applications\\aws_dashboard\\pages\\feature_sets\\callbacks.py applications\\aws_dashboard\\pages\\feature_sets\\page.py tests\\specific\\loading_state_test.py
- py -m isort --profile black --line-length 120 --check-only src\\workbench\\web_interface\\components\\loading_state.py applications\\aws_dashboard\\pages\\data_sources\\callbacks.py applications\\aws_dashboard\\pages\\data_sources\\page.py applications\\aws_dashboard\\pages\\feature_sets\\callbacks.py applications\\aws_dashboard\\pages\\feature_sets\\page.py tests\\specific\\loading_state_test.py
- git diff --check